### PR TITLE
Geolocation and Position conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+test

--- a/formatOpportunities.js
+++ b/formatOpportunities.js
@@ -1,0 +1,12 @@
+var fs = require('fs');
+
+var fileName = process.argv[2];
+var text = fs.readFileSync(fileName, "utf8");
+var newFileName = fileName.split(".",1) + ".new.json";
+
+var opportunties = JSON.parse(text);
+
+var out = fs.createWriteStream(fileName, { encoding: "utf8" });
+out.write(JSON.stringify(opportunties, null, 2));
+out.end(); 
+

--- a/formatOpportunities.js
+++ b/formatOpportunities.js
@@ -1,12 +1,32 @@
 var fs = require('fs');
 
 var fileName = process.argv[2];
-var text = fs.readFileSync(fileName, "utf8");
-var newFileName = fileName.split(".",1) + ".new.json";
 
-var opportunties = JSON.parse(text);
+if (fileName) {
+	try {
+		var text = fs.readFileSync(fileName, "utf8");
+		var opportunties = JSON.parse(text);
+	} catch (e) {
+		console.log("ERROR: " + e.message);
+		process.exit(1);
+	}
+	
+	try {
+		var out = fs.createWriteStream(fileName, { encoding: "utf8" });
+		out.write(JSON.stringify(opportunties, null, 2));
+		out.end(); 
+	} catch (e) {
+		console.log("ERROR: Couldn't write content out to: " + fileName + "");
+		console.log("ERROR: " + e.message);
+		process.exit(1);
+	}
+} else {
+	function getFileName(path) {
+		return path.substring(path.lastIndexOf('/') + 1, path.length);
+	}
+	var node = getFileName(process.argv[0]);
 
-var out = fs.createWriteStream(fileName, { encoding: "utf8" });
-out.write(JSON.stringify(opportunties, null, 2));
-out.end(); 
+	var script = getFileName(process.argv[1]);
 
+	console.log("Usage: " + node + " " + script + " <filename>");
+}

--- a/philadelphia.json
+++ b/philadelphia.json
@@ -3,9 +3,9 @@
     "company": "160over90",
     "url": "http://www.160over90.com/careers/",
     "address": "1 S. Broad St., 10th Floor, Philadelphia, PA 19107",
-    "location": {
-      "lat": 39.951591,
-      "lng": -75.163514
+    "geo": {
+      "latitude": 39.951591,
+      "longitude": -75.163514
     },
     "positions": [
       "Account Supervisor",
@@ -20,9 +20,9 @@
     "company": "50onRed",
     "url": "http://50onred.theresumator.com/?utm_source=github",
     "address": "2929 Arch St, Philadelphia, PA 19104",
-    "location": {
-      "lat": 39.956848137931,
-      "lng": -75.18091562069
+    "geo": {
+      "latitude": 39.956848137931,
+      "longitude": -75.18091562069
     },
     "positions": [
       "Data Scientist",
@@ -39,9 +39,9 @@
     "company": "AboutOne",
     "url": "http://www.aboutone.com/jobs/",
     "address": "26 Raffaela Drive, Malvern, PA 19355",
-    "location": {
-      "lat": 40.039942,
-      "lng": -75.5103515
+    "geo": {
+      "latitude": 40.039942,
+      "longitude": -75.5103515
     },
     "positions": [
       "SENIOR iOS DEVELOPER",
@@ -53,9 +53,9 @@
     "company": "Al Día",
     "url": "http://aldianews.com/pages/careers/34548",
     "address": "1835 Market St, Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.9532393469,
-      "lng": -75.1705572449
+    "geo": {
+      "latitude": 39.9532393469,
+      "longitude": -75.1705572449
     },
     "positions": []
   },
@@ -63,9 +63,9 @@
     "company": "Allen & Gerritsen",
     "url": "http://www.a-g.com/careers/",
     "address": "619 Walnut St, Philadelphia, PA 19128",
-    "location": {
-      "lat": 39.9461686667,
-      "lng": -75.15197
+    "geo": {
+      "latitude": 39.9461686667,
+      "longitude": -75.15197
     },
     "positions": [
       "Analytics Manager"
@@ -75,9 +75,9 @@
     "company": "ApprenNet",
     "url": "http://info.apprennet.com/jobs/",
     "address": "1007 E Abington Ave, Wyndmoor, PA 19038",
-    "location": {
-      "lat": 40.0839338571,
-      "lng": -75.191686898
+    "geo": {
+      "latitude": 40.0839338571,
+      "longitude": -75.191686898
     },
     "positions": [
       "Lead QA Engineer"
@@ -87,9 +87,9 @@
     "company": "Aramark",
     "url": "https://allcareers-aramark.icims.com/jobs/search?ss=1&searchLocation=12781-12822-",
     "address": "Philadelphia",
-    "location": {
-      "lat": 40.07231,
-      "lng": -75.203371
+    "geo": {
+      "latitude": 40.07231,
+      "longitude": -75.203371
     },
     "positions": [
       "Graphic Designer Manager - Sales Support"
@@ -99,9 +99,9 @@
     "company": "Arc Intermedia",
     "url": "http://www.arcintermedia.com/company/careers/",
     "address": "1150 First Ave., Suite 501, King of Prussia, PA 19406",
-    "location": {
-      "lat": 40.0950185455,
-      "lng": -75.4155636667
+    "geo": {
+      "latitude": 40.0950185455,
+      "longitude": -75.4155636667
     },
     "positions": [
       "Entry/Mid-Level Inbound Marketing Manager Position",
@@ -116,9 +116,9 @@
     "company": "Arcweb",
     "url": "https://arcweb.co/careers/",
     "address": "234 Market St, Philadelphia, PA 19106",
-    "location": {
-      "lat": 39.950092,
-      "lng": -75.1449277143
+    "geo": {
+      "latitude": 39.950092,
+      "longitude": -75.1449277143
     },
     "positions": [
       "Android Developer",
@@ -134,9 +134,9 @@
     "company": "AWeber Communications",
     "url": "http://www.aweber.jobs/",
     "address": "1100 Manor Drive, Chalfont PA, 18914",
-    "location": {
-      "lat": 40.268983,
-      "lng": -75.222586
+    "geo": {
+      "latitude": 40.268983,
+      "longitude": -75.222586
     },
     "positions": [
       "Front End Engineer",
@@ -150,9 +150,9 @@
     "company": "Azavea",
     "url": "http://jobs.azavea.com/",
     "address": "340 N 12th St, Suite 402, Philadelphia, PA",
-    "location": {
-      "lat": 39.9587179412,
-      "lng": -75.1583954412
+    "geo": {
+      "latitude": 39.9587179412,
+      "longitude": -75.1583954412
     },
     "positions": [
       "Operations Engineer"
@@ -162,9 +162,9 @@
     "company": "baseklas",
     "url": "http://baseklas.com/jobs/",
     "address": "128 Chestnut Street, Suite 304, Philadelphia PA 19106",
-    "location": {
-      "lat": 39.948286125,
-      "lng": -75.143379125
+    "geo": {
+      "latitude": 39.948286125,
+      "longitude": -75.143379125
     },
     "positions": [
       "Groovy designer needed!"
@@ -174,9 +174,9 @@
     "company": "Billy Penn",
     "url": "https://billypenn.com/jobs/",
     "address": "15th, 30 S 15th St, Philadelphia, PA 19102",
-    "location": {
-      "lat": 39.949553,
-      "lng": -75.165939
+    "geo": {
+      "latitude": 39.949553,
+      "longitude": -75.165939
     },
     "positions": [
       "Freelance Developers"
@@ -186,9 +186,9 @@
     "company": "Biomeme, Inc.",
     "url": "http://www.biomeme.com/",
     "address": "2025 Washington Avenue",
-    "location": {
-      "lat": 39.9390814898,
-      "lng": -75.1767853469
+    "geo": {
+      "latitude": 39.9390814898,
+      "longitude": -75.1767853469
     },
     "positions": []
   },
@@ -196,9 +196,9 @@
     "company": "Bluecadet",
     "url": "http://www.bluecadet.com/contact/careers/",
     "address": "1011 N Hancock st, Philadelphia PA 19123",
-    "location": {
-      "lat": 39.965753,
-      "lng": -75.1392843333
+    "geo": {
+      "latitude": 39.965753,
+      "longitude": -75.1392843333
     },
     "positions": [
       "iOS Developer",
@@ -211,9 +211,9 @@
     "company": "Boomi",
     "url": "http://www.boomi.com/company/careers",
     "address": "801 Cassatt Road Suite 111 Berwyn, PA 19312",
-    "location": {
-      "lat": 40.062366,
-      "lng": -75.456169
+    "geo": {
+      "latitude": 40.062366,
+      "longitude": -75.456169
     },
     "positions": [
       "Software Develoment Engineer",
@@ -227,9 +227,9 @@
     "company": "BresslerGroup",
     "url": "http://www.bresslergroup.com/about/#jobs",
     "address": "7th floor, 1216 Arch St, Philadelphia, PA 19107",
-    "location": {
-      "lat": 39.951735,
-      "lng": -75.158654
+    "geo": {
+      "latitude": 39.951735,
+      "longitude": -75.158654
     },
     "positions": [
       "Senior Product Development Engineer",
@@ -242,9 +242,9 @@
     "company": "BrickSimple LLC",
     "url": "http://bricksimple.com/",
     "address": "22 S Main St, Doylestown, PA 18901",
-    "location": {
-      "lat": 40.309501,
-      "lng": -75.1301983333
+    "geo": {
+      "latitude": 40.309501,
+      "longitude": -75.1301983333
     },
     "positions": [
       "Senior iOS Developer",
@@ -255,9 +255,9 @@
     "company": "Brolik",
     "url": "http://brolik.com/careers",
     "address": "421 N. 7th St., Suite 701, Philadelphia PA 19123",
-    "location": {
-      "lat": 39.9591977619,
-      "lng": -75.1502415238
+    "geo": {
+      "latitude": 39.9591977619,
+      "longitude": -75.1502415238
     },
     "positions": []
   },
@@ -265,9 +265,9 @@
     "company": "BuLogics",
     "url": "http://bulogics.com/about-us/jobs/",
     "address": "3721 Midvale Ave, Philadelphia, PA 19129",
-    "location": {
-      "lat": 40.00971845,
-      "lng": -75.19331115
+    "geo": {
+      "latitude": 40.00971845,
+      "longitude": -75.19331115
     },
     "positions": [
       "Lead Firmware Engineer",
@@ -279,9 +279,9 @@
     "company": "CardConnect",
     "url": "https://www.cardconnect.com/contact/job-openings/",
     "address": "1000 Continental Dr Suite 600, King of Prussia, PA 19406",
-    "location": {
-      "lat": 40.081367,
-      "lng": -75.399611
+    "geo": {
+      "latitude": 40.081367,
+      "longitude": -75.399611
     },
     "positions": [
       "SAP ERP Developer",
@@ -297,9 +297,9 @@
     "company": "Chariot Solutions",
     "url": "http://chariotsolutions.com/who-we-are/careers/",
     "address": "515 Pennsylvania Ave #202, Fort Washington, PA 19034",
-    "location": {
-      "lat": 40.134146,
-      "lng": -75.2061795
+    "geo": {
+      "latitude": 40.134146,
+      "longitude": -75.2061795
     },
     "positions": [
       "Scala Developers",
@@ -311,9 +311,9 @@
     "company": "ChatterBlast Media",
     "url": "http://chatterblast.com/careers/",
     "address": "1315 Walnut Street, Suite 800, Philadelphia, PA 19107",
-    "location": {
-      "lat": 39.9491672,
-      "lng": -75.1628294
+    "geo": {
+      "latitude": 39.9491672,
+      "longitude": -75.1628294
     },
     "positions": []
   },
@@ -321,9 +321,9 @@
     "company": "Circulate",
     "url": "http://www.circulate.com/jobs/index.html",
     "address": "200 S. Broad Street, Suite 915",
-    "location": {
-      "lat": 39.949345,
-      "lng": -75.164338
+    "geo": {
+      "latitude": 39.949345,
+      "longitude": -75.164338
     },
     "positions": []
   },
@@ -331,9 +331,9 @@
     "company": "Cloudamize",
     "url": "http://www.cloudamize.com/careers/",
     "address": "1735 Market St Suite 2502",
-    "location": {
-      "lat": 39.9530423469,
-      "lng": -75.1689862653
+    "geo": {
+      "latitude": 39.9530423469,
+      "longitude": -75.1689862653
     },
     "positions": [
       "Solutions Engineer",
@@ -345,9 +345,9 @@
     "company": "CloudMine",
     "url": "https://jobs.lever.co/cloudmine",
     "address": "1315 Walnut Street, Philadelphia PA, 19107",
-    "location": {
-      "lat": 39.9491672,
-      "lng": -75.1628294
+    "geo": {
+      "latitude": 39.9491672,
+      "longitude": -75.1628294
     },
     "positions": [
       "Senior Interaction Designer"
@@ -357,9 +357,9 @@
     "company": "Club OS",
     "url": "https://angel.co/club-os/jobs",
     "address": "1650 Arch St, #1906, Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.9549139592,
-      "lng": -75.1671930612
+    "geo": {
+      "latitude": 39.9549139592,
+      "longitude": -75.1671930612
     },
     "positions": [
       "Senior Java Sofware Engineer",
@@ -371,9 +371,9 @@
     "company": "Clutch",
     "url": "https://www.clutch.com/careers/",
     "address": "201 S Maple St #250, Ambler, PA 19002",
-    "location": {
-      "lat": 40.1561585849,
-      "lng": -75.2278333396
+    "geo": {
+      "latitude": 40.1561585849,
+      "longitude": -75.2278333396
     },
     "positions": [
       "SENIOR DATA SCIENTIST",
@@ -384,9 +384,9 @@
     "company": "Curalate",
     "url": "https://boards.greenhouse.io/curalate#.VkAHsa6rRE5",
     "address": "2401 Walnut St #502, Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.95124,
-      "lng": -75.179508
+    "geo": {
+      "latitude": 39.95124,
+      "longitude": -75.179508
     },
     "positions": [
       "Product Manager",
@@ -400,9 +400,9 @@
     "company": "D4 Creative Group",
     "url": "http://www.d4creative.com/careers",
     "address": "4646 Umbria Street",
-    "location": {
-      "lat": 40.0305332308,
-      "lng": -75.2300390769
+    "geo": {
+      "latitude": 40.0305332308,
+      "longitude": -75.2300390769
     },
     "positions": [
       "Copywriter",
@@ -416,9 +416,9 @@
     "company": "Delphic Digital",
     "url": "http://www.delphicdigital.com/about/careers/open-positions",
     "address": "116 Shurs Lane, 2nd Floor, Philadelphia, PA 19127",
-    "location": {
-      "lat": 40.022712,
-      "lng": -75.217571
+    "geo": {
+      "latitude": 40.022712,
+      "longitude": -75.217571
     },
     "positions": [
       "Technical Project Manager",
@@ -442,9 +442,9 @@
     "company": "DramaFever",
     "url": "http://www.dramafever.com/company/careers.html",
     "address": "1717 Arch St, Suite 601, Philadelphia, PA",
-    "location": {
-      "lat": 39.9546511633,
-      "lng": -75.1650889796
+    "geo": {
+      "latitude": 39.9546511633,
+      "longitude": -75.1650889796
     },
     "positions": [
       "Android Developer",
@@ -456,9 +456,9 @@
     "company": "Dronecast",
     "url": "http://www.dronecast.com/careers/",
     "address": "1700 Market Street, Suite 1005, Philadelphia PA",
-    "location": {
-      "lat": 39.952974,
-      "lng": -75.168444
+    "geo": {
+      "latitude": 39.952974,
+      "longitude": -75.168444
     },
     "positions": [
       "Graphic Designe",
@@ -470,9 +470,9 @@
     "company": "Eastern Standard",
     "url": "http://easternstandard.com/pages/careers",
     "address": "261 Old York Rd. Suite 617 Jenkintown, PA 19046",
-    "location": {
-      "lat": 40.093339,
-      "lng": -75.125276
+    "geo": {
+      "latitude": 40.093339,
+      "longitude": -75.125276
     },
     "positions": [
       "DIGITAL MARKETING COORDINATOR",
@@ -483,9 +483,9 @@
     "company": "Economy League of Greater Philadelphia",
     "url": "http://economyleague.org/about-us/join-our-team",
     "address": "230 S Broad St, Philadelphia PA 19102",
-    "location": {
-      "lat": 39.94878,
-      "lng": -75.1644585
+    "geo": {
+      "latitude": 39.94878,
+      "longitude": -75.1644585
     },
     "positions": []
   },
@@ -493,9 +493,9 @@
     "company": "eMoney Advisor",
     "url": "http://emoneyadvisor.theresumator.com/apply",
     "address": "1001 E Hector St, Conshohocken, PA 19428",
-    "location": {
-      "lat": 40.07517,
-      "lng": -75.289722
+    "geo": {
+      "latitude": 40.07517,
+      "longitude": -75.289722
     },
     "positions": [
       "Data Services Support Specialist",
@@ -514,9 +514,9 @@
     "company": "EPAM",
     "url": "http://www.epam.com/careers",
     "address": "101 E 8th Ave #201, Conshohocken, PA 19428",
-    "location": {
-      "lat": 40.079189,
-      "lng": -75.299617
+    "geo": {
+      "latitude": 40.079189,
+      "longitude": -75.299617
     },
     "positions": [
       "Senior Project Manager",
@@ -527,9 +527,9 @@
     "company": "Evoke Health",
     "url": "http://www.evokehealth.com/Careers",
     "address": "1 South Broad St., 13th Floor, Philadelphia, PA",
-    "location": {
-      "lat": 39.951591,
-      "lng": -75.163514
+    "geo": {
+      "latitude": 39.951591,
+      "longitude": -75.163514
     },
     "positions": []
   },
@@ -537,9 +537,9 @@
     "company": "Evolve IP",
     "url": "http://www.evolveip.net/about/careers",
     "address": "989 Old Eagle School Rd, Wayne, PA 19087",
-    "location": {
-      "lat": 40.076770625,
-      "lng": -75.41092975
+    "geo": {
+      "latitude": 40.076770625,
+      "longitude": -75.41092975
     },
     "positions": [
       "Project Manager",
@@ -550,9 +550,9 @@
     "company": "Fynydd",
     "url": "https://fynydd.com/careers/",
     "address": "630 Freedom Business Center Drive, King of Prussia, PA 19406",
-    "location": {
-      "lat": 40.0922677347,
-      "lng": -75.4162122857
+    "geo": {
+      "latitude": 40.0922677347,
+      "longitude": -75.4162122857
     },
     "positions": [
       "Senior Developer"
@@ -562,9 +562,9 @@
     "company": "Garfield Group",
     "url": "http://garfieldgroup.com/careers",
     "address": "60 Blacksmith Road, Newtown PA 18940",
-    "location": {
-      "lat": 40.222709625,
-      "lng": -74.915183875
+    "geo": {
+      "latitude": 40.222709625,
+      "longitude": -74.915183875
     },
     "positions": [
       "Copywriter",
@@ -576,9 +576,9 @@
     "company": "GatherDocs",
     "url": "http://jobs.gatherdocs.com/",
     "address": "4040 Locust St, Philadelphia, PA 19104",
-    "location": {
-      "lat": 39.9531008333,
-      "lng": -75.2038928333
+    "geo": {
+      "latitude": 39.9531008333,
+      "longitude": -75.2038928333
     },
     "positions": [
       "PHP Web Developer",
@@ -599,9 +599,9 @@
     "company": "Graphene Frontiers",
     "url": "http://graphenefrontiers.com/careers/",
     "address": "3624 Market St. FL 5th, Philadelphia, PA 19104",
-    "location": {
-      "lat": 39.9562402245,
-      "lng": -75.1946339592
+    "geo": {
+      "latitude": 39.9562402245,
+      "longitude": -75.1946339592
     },
     "positions": [
       "Biosensor Research and Development Technician",
@@ -613,9 +613,9 @@
     "company": "Here's My Chance",
     "url": "http://heresmychance.com/careers/",
     "address": "121 S. 13th Street 4th Floor Philadelphia, PA 19107",
-    "location": {
-      "lat": 39.949836,
-      "lng": -75.161949
+    "geo": {
+      "latitude": 39.949836,
+      "longitude": -75.161949
     },
     "positions": [
       "Copywriter",
@@ -626,9 +626,9 @@
     "company": "InstaMed",
     "url": "http://www.instamed.com/about/careers/",
     "address": "1880 JFK Boulevard  12th floor, Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.952896,
-      "lng": -75.174298
+    "geo": {
+      "latitude": 39.952896,
+      "longitude": -75.174298
     },
     "positions": [
       "Information Systems – Senior Analyst/Manager",
@@ -640,9 +640,9 @@
     "company": "Intuitive Company",
     "url": "http://intuitivecompany.com/careers/",
     "address": "3 Rector Street, Philadelphia PA, 19127",
-    "location": {
-      "lat": 40.0241577959,
-      "lng": -75.2220595102
+    "geo": {
+      "latitude": 40.0241577959,
+      "longitude": -75.2220595102
     },
     "positions": [
       "User Experience Researcher",
@@ -653,9 +653,9 @@
     "company": "Inverse Paradox",
     "url": "https://www.inverseparadox.com/careers/",
     "address": "133 Bellevue Ave., Penndel, PA 19047",
-    "location": {
-      "lat": 40.1584053469,
-      "lng": -74.9120337959
+    "geo": {
+      "latitude": 40.1584053469,
+      "longitude": -74.9120337959
     },
     "positions": [
       "PHP Developer – Magento",
@@ -666,9 +666,9 @@
     "company": "LeadiD",
     "url": "http://www.leadid.com/about-us/join-our-team/open-positions",
     "address": "201 S Maple St, Ambler, PA, 19002",
-     "location": {
-      "lat": 40.1561585849,
-      "lng": -75.2278333396
+     "geo": {
+      "latitude": 40.1561585849,
+      "longitude": -75.2278333396
     },
     "positions": [
       "Manager/Director - DevOps",
@@ -680,9 +680,9 @@
     "company": "Leadnomics",
     "url": "http://www.leadnomics.com/careers/",
     "address": "2929 Arch St, Philadelphia, PA 19104",
-    "location": {
-      "lat": 39.9568481379,
-      "lng": -75.1809156207
+    "geo": {
+      "latitude": 39.9568481379,
+      "longitude": -75.1809156207
     },
     "positions": [
       "Associate Software Engineer",
@@ -693,9 +693,9 @@
     "company": "LevelUp",
     "url": "https://www.thelevelup.com/jobs",
     "address": "1628 JFK Blvd., Philadelphia, PA",
-    "location": {
-      "lat": 40.214982,
-      "lng": -75.265441
+    "geo": {
+      "latitude": 40.214982,
+      "longitude": -75.265441
     },
     "positions": [
       ".NET Software Engineer",
@@ -711,9 +711,9 @@
     "company": "Medecision",
     "url": "https://careers-medecision.icims.com/jobs/intro?hashed=-435743548",
     "address": "550 E Swedesford Rd #220, Wayne, PA 19087",
-    "location": {
-      "lat": 40.0755407626,
-      "lng": -75.4241920791
+    "geo": {
+      "latitude": 40.0755407626,
+      "longitude": -75.4241920791
     },
     "positions": [
       "Director, Data Management",
@@ -726,9 +726,9 @@
     "company": "MeetMe",
     "url": "http://www.meetme.com/apps/careers#careers-position",
     "address": "100 Union Square Drive, New Hope, PA",
-    "location": {
-      "lat": 40.314,
-      "lng": -75.131903
+    "geo": {
+      "latitude": 40.314,
+      "longitude": -75.131903
     },
     "positions": [
       "Software Architect, API New Hope, PA, United States",
@@ -743,9 +743,9 @@
     "company": "MentorTech Ventures",
     "url": "http://www.mentortechventures.com/jobs",
     "address": "3624 Market Street, Suite 300, Philadelphia, PA",
-    "location": {
-      "lat": 39.9562402245,
-      "lng": -75.1946339592
+    "geo": {
+      "latitude": 39.9562402245,
+      "longitude": -75.1946339592
     },
     "positions": [
       "iOS Developer",
@@ -759,9 +759,9 @@
     "company": "Metropolitan Acoustics",
     "url": "http://metro-acoustics.com/careers",
     "address": "40 West Evergreen Avenue Suite 108, Philadelphia, PA 19118",
-    "location": {
-      "lat": 40.0759209111,
-      "lng": -75.2081357556
+    "geo": {
+      "latitude": 40.0759209111,
+      "longitude": -75.2081357556
     },
     "positions": []
   },
@@ -769,9 +769,9 @@
     "company": "MOD Worldwide",
     "url": "http://www.modworldwide.com/creative.html",
     "address": "121 S Broad St, Philadelphia, PA 19107",
-    "location": {
-      "lat": 39.950696,
-      "lng": -75.1638900816
+    "geo": {
+      "latitude": 39.950696,
+      "longitude": -75.1638900816
     },
     "positions": [
       "GRAPHIC DESIGNER",
@@ -787,9 +787,9 @@
     "company": "Momentum Dynamics",
     "url": "http://www.momentumdynamics.com/momentum-dynamics.html#careers",
     "address": "3 Pennsylvania Avenue, Malvern, PA 19355",
-    "location": {
-      "lat": 40.0374198571,
-      "lng": -75.5168733857
+    "geo": {
+      "latitude": 40.0374198571,
+      "longitude": -75.5168733857
     },
     "positions": [
       "Embedded Software Engineers"
@@ -799,9 +799,9 @@
     "company": "Monetate, Inc.",
     "url": "http://www.monetate.com/about/careers/#open-positions",
     "address": "951 E. Hector Street, Conshohocken PA 19428",
-    "location": {
-      "lat": 40.0750470612,
-      "lng": -75.2904890204
+    "geo": {
+      "latitude": 40.0750470612,
+      "longitude": -75.2904890204
     },
     "positions": [
       "Director of Delivery Engineering",
@@ -814,9 +814,9 @@
     "company": "Morgan Lewis",
     "url": "https://sjobs.brassring.com/TGWebHost/home.aspx?partnerid=25936&siteid=5172",
     "address": "1701 Market St Philadelphia",
-    "location": {
-      "lat": 39.952974,
-      "lng": -75.168444
+    "geo": {
+      "latitude": 39.952974,
+      "longitude": -75.168444
     },
     "positions": [
       "640BR Manager of IT Infrastructure Engineering",
@@ -829,9 +829,9 @@
     "company": "Municibid",
     "url": "https://municibid.com/jobs/",
     "address": "200 Barr Harbor Drive Suite 4, Conshohocken, PA 19428",
-    "location": {
-      "lat": 40.085953,
-      "lng": -75.115217
+    "geo": {
+      "latitude": 40.085953,
+      "longitude": -75.115217
     },
     "positions": []
   },
@@ -839,9 +839,9 @@
     "company": "Nasdaq OMX",
     "url": "https://careersus-nasdaq.icims.com/jobs/search?ss=1&searchLocation=12781-12822-philadelphia",
     "address": "1900 Market St,Philadelphia, PA",
-    "location": {
-      "lat": 39.953368,
-      "lng": -75.171593
+    "geo": {
+      "latitude": 39.953368,
+      "longitude": -75.171593
     },
     "positions": [
       "Product Management Sr Spec",
@@ -852,9 +852,9 @@
     "company": "National Constitution Center",
     "url": "http://constitutioncenter.org/about/careers/paid-positions/",
     "address": "Independence Mall 525 Arch Street, Philadelphia, PA 19106",
-    "location": {
-      "lat": 39.950063,
-      "lng": -75.149022
+    "geo": {
+      "latitude": 39.950063,
+      "longitude": -75.149022
     },
     "positions": []
   },
@@ -862,9 +862,9 @@
     "company": "NavigationArts",
     "url": "http://www.navigationarts.com/our-company/careers",
     "address": "125 North 3rd Street, Floor 4",
-    "location": {
-      "lat": 39.9528668,
-      "lng": -75.1450802
+    "geo": {
+      "latitude": 39.9528668,
+      "longitude": -75.1450802
     },
     "positions": [
       "Interactive Visual Designer",
@@ -882,9 +882,9 @@
     "company": "Netplus",
     "url": "http://thinknetplus.com/contact/#netplus-jobs",
     "address": "718 Arch St Suite #400S",
-    "location": {
-      "lat": 39.9529856531,
-      "lng": -75.1518336122
+    "geo": {
+      "latitude": 39.9529856531,
+      "longitude": -75.1518336122
     },
     "positions": [
       "Web Developer Full-Stack",
@@ -896,9 +896,9 @@
     "company": "Nimblelight",
     "url": "http://nimblelight.com/jobs/",
     "address": "4355 Orchard St, Philadelphia PA, 19124",
-    "location": {
-      "lat": 40.0109041224,
-      "lng": -75.0858912041
+    "geo": {
+      "latitude": 40.0109041224,
+      "longitude": -75.0858912041
     },
     "positions": [
       "Developer"
@@ -908,9 +908,9 @@
     "company": "O3 World",
     "url": "http://o3world.com/careers/",
     "address": "1000 N. Hancock St. Suite 103 Philadelphia PA, 19123",
-    "location": {
-      "lat": 39.9652262979,
-      "lng": -75.1398402553
+    "geo": {
+      "latitude": 39.9652262979,
+      "longitude": -75.1398402553
     },
     "positions": [
       "PROJECT MANAGER",
@@ -925,9 +925,9 @@
     "company": "Offshorent",
     "url": "http://offshorent.com/careers",
     "address": "1000 W. Valley Forge Circle. #110A. King Of Prussia, PA 19406",
-    "location": {
-      "lat": 40.1030152727,
-      "lng": -75.4137162727
+    "geo": {
+      "latitude": 40.1030152727,
+      "longitude": -75.4137162727
     },
     "positions": [
       "Sr. Java Programmer",
@@ -940,9 +940,9 @@
     "company": "PCS Trac",
     "url": "http://www.pcstrac.com/#!careers/cuev",
     "address": "4250 Wissahickon Ave, Philadelphia, PA 19129",
-    "location": {
-      "lat": 40.0149365556,
-      "lng": -75.1698068384
+    "geo": {
+      "latitude": 40.0149365556,
+      "longitude": -75.1698068384
     },
     "positions": []
   },
@@ -950,9 +950,9 @@
     "company": "Pedrera Philadelphia Web Development",
     "url": "http://pedrera.com/about-us/careers",
     "address": "100 Mechanics Street, Doylestown, PA 18901",
-     "location": {
-      "lat": 40.3136617818,
-      "lng": -75.1289168909
+     "geo": {
+      "latitude": 40.3136617818,
+      "longitude": -75.1289168909
     },
     "positions": [
       "Web Developer"
@@ -962,9 +962,9 @@
     "company": "PeopleLinx",
     "url": "http://peoplelinx.com/careers/",
     "address": "1835 Market Street, Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.9532393469,
-      "lng": -75.1705572449
+    "geo": {
+      "latitude": 39.9532393469,
+      "longitude": -75.1705572449
     },
     "positions": []
   },
@@ -972,9 +972,9 @@
     "company": "Philadelphia Convention & Visitors Bureau PHLCVB",
     "url": "http://www.discoverphl.com/about-PHLCVB/employment/",
     "address": "1700 Market St., Suite 3000 Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.952974,
-      "lng": -75.168444
+    "geo": {
+      "latitude": 39.952974,
+      "longitude": -75.168444
     },
     "positions": []
   },
@@ -982,9 +982,9 @@
     "company": "Philly Marketing Labs",
     "url": "http://www.phillymarketinglabs.com/join-our-team/",
     "address": "224 Lansdowne Ave, Wayne, PA 19087",
-     "location": {
-      "lat": 40.040375898,
-      "lng": -75.3892247755
+     "geo": {
+      "latitude": 40.040375898,
+      "longitude": -75.3892247755
     },
     "positions": [
       "Web Marketing Project Manager"
@@ -994,9 +994,9 @@
     "company": "Picwell",
     "url": "https://careers.picwell.com/",
     "address": "2200 Arch St Suite 101, Philadelphia PA 19103",
-    "location": {
-      "lat": 39.9558749,
-      "lng": -75.1790956
+    "geo": {
+      "latitude": 39.9558749,
+      "longitude": -75.1790956
     },
     "positions": [
       "Software Engineer",
@@ -1008,9 +1008,9 @@
     "company": "PipelineDeals",
     "url": "https://www.pipelinedeals.com/careers",
     "address": "565 E. Swedesford Road, Suite 206, Wayne, PA 19087",
-    "location": {
-      "lat": 40.076011027,
-      "lng": -75.4230364054
+    "geo": {
+      "latitude": 40.076011027,
+      "longitude": -75.4230364054
     },
     "positions": [
       "Senior Product Manager",
@@ -1021,9 +1021,9 @@
     "company": "Plan Management Corp.",
     "url": "http://www.optiontrax.com/about-us/working-here/",
     "address": "44 W. Lancaster Ave, Suite 145, Ardmore PA, 19003",
-    "location": {
-      "lat": 40.0086664118,
-      "lng": -75.2925611765
+    "geo": {
+      "latitude": 40.0086664118,
+      "longitude": -75.2925611765
     },
     "positions": []
   },
@@ -1031,9 +1031,9 @@
     "company": "Plum Analytics",
     "url": "http://plumanalytics.com/about/careers/",
     "address": "808 Firethorn Circle, Dresher PA 19025",
-     "location": {
-      "lat": 40.1518441224,
-      "lng": -75.1554711633
+     "geo": {
+      "latitude": 40.1518441224,
+      "longitude": -75.1554711633
     },
     "positions": [
       "Senior Engineer / Architect (Big Data)",
@@ -1045,9 +1045,9 @@
     "company": "PromptWorks",
     "url": "http://www.promptworks.com/jobs/",
     "address": "1211 Chestnut St, Suite 400, Philadelphia PA, 19107",
-    "location": {
-      "lat": 39.9504152041,
-      "lng": -75.1603696122
+    "geo": {
+      "latitude": 39.9504152041,
+      "longitude": -75.1603696122
     },
     "positions": [
       "Senior Software Engineer",
@@ -1059,9 +1059,9 @@
     "company": "Pulsar Informatics",
     "url": "http://www.pulsarinformatics.com/about.html#anchor_positions",
     "address": "3401 Market Street, Philadelphia, PA 19104",
-    "location": {
-      "lat": 39.955843,
-      "lng": -75.191464
+    "geo": {
+      "latitude": 39.955843,
+      "longitude": -75.191464
     },
     "positions": [
       "Senior Software Developer"
@@ -1071,9 +1071,9 @@
     "company": "P'unk Avenue",
     "url": "http://punkave.com/connect",
     "address": "1168 E. Passyunk Avenue Philadelphia, PA 19147",
-    "location": {
-      "lat": 39.9345045143,
-      "lng": -75.1578163143
+    "geo": {
+      "latitude": 39.9345045143,
+      "longitude": -75.1578163143
     },
     "positions": [
       "Designer"
@@ -1083,9 +1083,9 @@
     "company": "Push10 Design",
     "url": "http://www.push10.com/blog/",
     "address": "125 NORTH 3RD ST, PHILA. PA 19106",
-     "location": {
-      "lat": 39.9528668,
-      "lng": -75.1450802
+     "geo": {
+      "latitude": 39.9528668,
+      "longitude": -75.1450802
     },
     "positions": [
       "WordPress Developer"
@@ -1095,9 +1095,9 @@
     "company": "Razorfish Health",
     "url": "http://www.publicishealthcare.com/en/careers/applyForJobs.aspx",
     "address": "100 Penn Square East, Philadelphia, PA 19107",
-    "location": {
-      "lat": 39.94491,
-      "lng": -75.159786
+    "geo": {
+      "latitude": 39.94491,
+      "longitude": -75.159786
     },
     "positions": []
   },
@@ -1105,9 +1105,9 @@
     "company": "RDA Corp",
     "url": "http://rdacorp.com/en/Careers/Current%20Openings",
     "address": "101 Lindenwood Drive Suite 225 Malvern, PA 19355",
-    "location": {
-      "lat": 40.049973,
-      "lng": -75.528712
+    "geo": {
+      "latitude": 40.049973,
+      "longitude": -75.528712
     },
     "positions": [
       "SharePoint Contractor",
@@ -1122,9 +1122,9 @@
     "company": "Red Tettemer O'Connell + Partners",
     "url": "http://www.rtop.com/contact/",
     "address": "1 S. Broad, 24th Floor, Philadelphia, PA",
-    "location": {
-      "lat": 40.241562,
-      "lng": -75.283746
+    "geo": {
+      "latitude": 40.241562,
+      "longitude": -75.283746
     },
     "positions": [
       "APP DEVELOPER"
@@ -1134,9 +1134,9 @@
     "company": "Relay",
     "url": "http://www.relaynetwork.com/careers/",
     "address": "201 king of prussia rd radnor pa 19087",
-    "location": {
-      "lat": 40.081206,
-      "lng": -75.388683
+    "geo": {
+      "latitude": 40.081206,
+      "longitude": -75.388683
     },
     "positions": [
       "Senior Client Project Manager",
@@ -1147,9 +1147,9 @@
     "company": "Revzilla",
     "url": "http://www.revzilla.com/careers",
     "address": "4020 S 26th St, Philadelphia, PA 19112",
-    "location": {
-      "lat": 39.936679,
-      "lng": -75.187326
+    "geo": {
+      "latitude": 39.936679,
+      "longitude": -75.187326
     },
     "positions": [
       "Web Developer",
@@ -1161,9 +1161,9 @@
     "company": "RightAction",
     "url": "http://rightaction.theresumator.com/",
     "address": "2929 Arch St, Philadelphia, PA 19104",
-    "location": {
-      "lat": 39.9568481379,
-      "lng": -75.1809156207
+    "geo": {
+      "latitude": 39.9568481379,
+      "longitude": -75.1809156207
     },
     "positions": [
       "Software Engineer, Java",
@@ -1174,9 +1174,9 @@
     "company": "RJMetrics",
     "url": "https://rjmetrics.com/jobs/",
     "address": "1339 Chestnut Street Suite 1500 Philadelphia PA, 19107",
-    "location": {
-      "lat": 39.9507376667,
-      "lng": -75.1629786667
+    "geo": {
+      "latitude": 39.9507376667,
+      "longitude": -75.1629786667
     },
     "positions": [
       "Director of Infrmation Security",
@@ -1189,9 +1189,9 @@
     "company": "roundCorner",
     "url": "http://www.roundcorner.com/job-postings/",
     "address": "16 E. Lancaster Ave, Ardmore, PA 19003",
-    "location": {
-      "lat": 40.0074736667,
-      "lng": -75.2902143333
+    "geo": {
+      "latitude": 40.0074736667,
+      "longitude": -75.2902143333
     },
     "positions": [
       "Data Architect",
@@ -1203,9 +1203,9 @@
     "company": "Savana, Inc.",
     "url": "http://savanainc.com/company/careers/",
     "address": "920 Cassatt Road, Suite 220, Berwyn, PA 19312",
-    "location": {
-      "lat": 40.06229052,
-      "lng": -75.45604168
+    "geo": {
+      "latitude": 40.06229052,
+      "longitude": -75.45604168
     },
     "positions": [
       "Software Developer"
@@ -1215,9 +1215,9 @@
     "company": "SEER Interactive",
     "url": "http://www.seerinteractive.com/careers/",
     "address": "1033 N 2nd Street, Philadelphia, PA",
-    "location": {
-      "lat": 39.9672323333,
-      "lng": -75.1400423333
+    "geo": {
+      "latitude": 39.9672323333,
+      "longitude": -75.1400423333
     },
     "positions": []
   },
@@ -1225,9 +1225,9 @@
     "company": "Sidecar",
     "url": "https://hello.getsidecar.com/careers-listing/",
     "address": "114 S. 13th Street, 3rd Floor, Philadelphia, PA 19107",
-    "location": {
-      "lat": 39.949836,
-      "lng": -75.161949
+    "geo": {
+      "latitude": 39.949836,
+      "longitude": -75.161949
     },
     "positions": [
       "Client Service Operations Manager",
@@ -1240,9 +1240,9 @@
     "company": "SnipSnap",
     "url": "http://www.snipsnap.it/snipsnap-jobs/",
     "address": "109 South 13th Street, Philadelphia, PA 19107",
-    "location": {
-      "lat": 39.950196,
-      "lng": -75.161868
+    "geo": {
+      "latitude": 39.950196,
+      "longitude": -75.161868
     },
     "positions": [
       "Product Designer (Android)"
@@ -1252,9 +1252,9 @@
     "company": "SpectiCast",
     "url": "http://www.specticast.com/en/contents/careers",
     "address": "210 West Rittenhouse Square, Suite 400, Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.9500479286,
-      "lng": -75.1728245
+    "geo": {
+      "latitude": 39.9500479286,
+      "longitude": -75.1728245
     },
     "positions": []
   },
@@ -1273,9 +1273,9 @@
     "company": "Technically Media",
     "url": "http://technicallymedia.com/careers",
     "address": "4040 Locust Street, Philadelphia, Pa.",
-    "location": {
-      "lat": 39.9531008333,
-      "lng": -75.2038928333
+    "geo": {
+      "latitude": 39.9531008333,
+      "longitude": -75.2038928333
     },
     "positions": []
   },
@@ -1283,9 +1283,9 @@
     "company": "Think Brownstone",
     "url": "https://www.thinkbrownstone.com/careers/",
     "address": "201 Fayette St, Conshohocken, PA 19428",
-    "location": {
-      "lat": 40.074711,
-      "lng": -75.305449
+    "geo": {
+      "latitude": 40.074711,
+      "longitude": -75.305449
     },
     "positions": [
       "Development Lead",
@@ -1298,9 +1298,9 @@
     "company": "Thomson Reuters",
     "url": "https://toc.taleo.net/careersection/advanced_search/moresearch.tl?keyword=Philadelphia",
     "address": "1500 Spring Garen Street, Philadelphia, PA 19130",
-    "location": {
-      "lat": 39.962595,
-      "lng": -75.163112
+    "geo": {
+      "latitude": 39.962595,
+      "longitude": -75.163112
     },
     "positions": [
       "Senior Program Manager",
@@ -1314,9 +1314,9 @@
     "company": "Thoughtbot",
     "url": "https://thoughtbot.com/jobs",
     "address": "2401 Walnut St, Suite 102, Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.95124,
-      "lng": -75.179508
+    "geo": {
+      "latitude": 39.95124,
+      "longitude": -75.179508
     },
     "positions": [
       "Development Director, Mobile",
@@ -1327,9 +1327,9 @@
     "company": "TicketLeap",
     "url": "http://ticketleap.theresumator.com/",
     "address": "2401 Walnut Street, Suite 502, Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.95124,
-      "lng": -75.179508
+    "geo": {
+      "latitude": 39.95124,
+      "longitude": -75.179508
     },
     "positions": []
   },
@@ -1337,9 +1337,9 @@
     "company": "Tonic Design Co",
     "url": "http://www.tonicdesign.com/jobs/",
     "address": "201 S State St; Suite 2B Newtown PA 18940",
-    "location": {
-      "lat": 40.226642,
-      "lng": -74.937063
+    "geo": {
+      "latitude": 40.226642,
+      "longitude": -74.937063
     },
     "positions": [
       "Experience Design Lead",
@@ -1352,9 +1352,9 @@
     "company": "Transmogrify",
     "url": "http://xmog.com/jobs",
     "address": "112 Fayette St., Conshohocken, PA 19428",
-    "location": {
-      "lat": 40.0739984286,
-      "lng": -75.306129102
+    "geo": {
+      "latitude": 40.0739984286,
+      "longitude": -75.306129102
     },
     "positions": [
       "Front-End / UI Developer",
@@ -1365,9 +1365,9 @@
     "company": "Velora Studios",
     "url": "http://www.velorastudios.com/jobs",
     "address": "Philadelphia",
-    "location": {
-      "lat": 40.07231,
-      "lng": -75.203371
+    "geo": {
+      "latitude": 40.07231,
+      "longitude": -75.203371
     },
     "positions": [
       "Ruby on Rails Lead Programmer",
@@ -1379,9 +1379,9 @@
     "company": "Vistar Media",
     "url": "http://www.vistarmedia.com/careers",
     "address": "332 S Smedley St, Philadelphia, PA 19103",
-    "location": {
-      "lat": 39.9471276977,
-      "lng": -75.1686654651
+    "geo": {
+      "latitude": 39.9471276977,
+      "longitude": -75.1686654651
     },
     "positions": [
       "Software Engineer"
@@ -1391,9 +1391,9 @@
     "company": "WebLinc LLC",
     "url": "http://www.weblinc.com/company/careers/",
     "address": "22 South 3rd Street Second Floor Philadelphia, PA 19106",
-    "location": {
-      "lat": 39.9497525,
-      "lng": -75.1457715
+    "geo": {
+      "latitude": 39.9497525,
+      "longitude": -75.1457715
     },
     "positions": [
       "Quality Assurance Manager",
@@ -1405,9 +1405,9 @@
     "company": "Wildbit",
     "url": "http://wildbit.com/jobs",
     "address": "20 N 3rd St Philadelphia PA 19106",
-    "location": {
-      "lat": 39.9505591429,
-      "lng": -75.1455902857
+    "geo": {
+      "latitude": 39.9505591429,
+      "longitude": -75.1455902857
     },
     "positions": [
       "Senior C# Developer",
@@ -1418,9 +1418,9 @@
     "company": "The Wilson Concept",
     "url": "http://thewilsonconcept.com/careers/",
     "address": "109 South 13th Street, Philadelphia PA 19107",
-    "location": {
-      "lat": 39.950196,
-      "lng": -75.161868
+    "geo": {
+      "latitude": 39.950196,
+      "longitude": -75.161868
     },
     "positions": []
   },
@@ -1428,9 +1428,9 @@
     "company": "Wingspan Technology",
     "url": "http://www.wingspan.com/career_open_positions/",
     "address": "460 Norristown Road Suite 200, Blue Bell, PA 19422",
-    "location": {
-      "lat": 40.133626,
-      "lng": -75.255467
+    "geo": {
+      "latitude": 40.133626,
+      "longitude": -75.255467
     },
     "positions": [
       "Software Engineer (All Levels)",
@@ -1441,9 +1441,9 @@
     "company": "Zivtech",
     "url": "https://www.zivtech.com/about/employment",
     "address": "The Philadelphia Building 1315 Walnut St, Suite 1500, Philadelphia, PA, 19107",
-    "location": {
-      "lat": 39.9491672,
-      "lng": -75.1628294
+    "geo": {
+      "latitude": 39.9491672,
+      "longitude": -75.1628294
     },
     "positions": [
       "Drupal Developers and Themers"
@@ -1464,9 +1464,9 @@
     "company": "Zonoff",
     "url": "https://zonoff.com/our-story/careers/",
     "address": "70 E. Swedesford Rd., Suite 120, Malvern, PA 19460",
-    "location": {
-      "lat": 40.051395125,
-      "lng": -75.5336614375
+    "geo": {
+      "latitude": 40.051395125,
+      "longitude": -75.5336614375
     },
     "positions": [
       "UI Designer",
@@ -1483,9 +1483,9 @@
     "company": "Zuppler",
     "url": "http://www.zupplerworks.com/careers.html",
     "address": "730 East Elm St, Suite 200, Conshohocken, PA 19428",
-    "location": {
-      "lat": 40.0738422857,
-      "lng": -75.2935051429
+    "geo": {
+      "latitude": 40.0738422857,
+      "longitude": -75.2935051429
     },
     "positions": []
   }

--- a/philadelphia.json
+++ b/philadelphia.json
@@ -912,7 +912,9 @@
     "company": "InterNACHI",
     "url": "https://internachi.recruitee.com/",
     "positions": [
-      "Senior Web Developer (PHP, MySQL, JS, HTML, CSS)"
+      {
+        "title": "Senior Web Developer (PHP, MySQL, JS, HTML, CSS)"
+      }
     ]
   },
   {

--- a/philadelphia.json
+++ b/philadelphia.json
@@ -8,14 +8,26 @@
       "longitude": -75.163514
     },
     "positions": [
-      "Account Supervisor",
-      "Account Director",
-      "Senior Copywriter",
-      "Senior Designer",
-      "Motion Graphics Designer",
-      "Video Editor"
+      {
+        "title": "Account Supervisor"
+      },
+      {
+        "title": "Account Director"
+      },
+      {
+        "title": "Senior Copywriter"
+      },
+      {
+        "title": "Senior Designer"
+      },
+      {
+        "title": "Motion Graphics Designer"
+      },
+      {
+        "title": "Video Editor"
+      }
     ]
- },
+  },
   {
     "company": "50onRed",
     "url": "http://50onred.theresumator.com/?utm_source=github",
@@ -25,14 +37,30 @@
       "longitude": -75.18091562069
     },
     "positions": [
-      "Data Scientist",
-      "DevOps Systems Engineer",
-      "Senior Software Engineer",
-      "Marketing and Communications Director",
-      "Head of Product Development",
-      "UX Designer",
-      "Sales Executive",
-      "VP of Sales"
+      {
+        "title": "Data Scientist"
+      },
+      {
+        "title": "DevOps Systems Engineer"
+      },
+      {
+        "title": "Senior Software Engineer"
+      },
+      {
+        "title": "Marketing and Communications Director"
+      },
+      {
+        "title": "Head of Product Development"
+      },
+      {
+        "title": "UX Designer"
+      },
+      {
+        "title": "Sales Executive"
+      },
+      {
+        "title": "VP of Sales"
+      }
     ]
   },
   {
@@ -44,9 +72,15 @@
       "longitude": -75.5103515
     },
     "positions": [
-      "SENIOR iOS DEVELOPER",
-      "QUALITY ASSURANCE ENGINEER",
-      "SENIOR SOFTWARE ENGINEER"
+      {
+        "title": "SENIOR iOS DEVELOPER"
+      },
+      {
+        "title": "QUALITY ASSURANCE ENGINEER"
+      },
+      {
+        "title": "SENIOR SOFTWARE ENGINEER"
+      }
     ]
   },
   {
@@ -68,7 +102,9 @@
       "longitude": -75.15197
     },
     "positions": [
-      "Analytics Manager"
+      {
+        "title": "Analytics Manager"
+      }
     ]
   },
   {
@@ -80,7 +116,9 @@
       "longitude": -75.191686898
     },
     "positions": [
-      "Lead QA Engineer"
+      {
+        "title": "Lead QA Engineer"
+      }
     ]
   },
   {
@@ -92,7 +130,9 @@
       "longitude": -75.203371
     },
     "positions": [
-      "Graphic Designer Manager - Sales Support"
+      {
+        "title": "Graphic Designer Manager - Sales Support"
+      }
     ]
   },
   {
@@ -104,12 +144,24 @@
       "longitude": -75.4155636667
     },
     "positions": [
-      "Entry/Mid-Level Inbound Marketing Manager Position",
-      "Junior Front-end Web Developer/Web Designer",
-      "Senior Level SEO Position",
-      "Entry-Mid Level SEO Position",
-      "Part-time Experienced SEO Professional",
-      "Umbraco ASP.NET Developer"
+      {
+        "title": "Entry/Mid-Level Inbound Marketing Manager Position"
+      },
+      {
+        "title": "Junior Front-end Web Developer/Web Designer"
+      },
+      {
+        "title": "Senior Level SEO Position"
+      },
+      {
+        "title": "Entry-Mid Level SEO Position"
+      },
+      {
+        "title": "Part-time Experienced SEO Professional"
+      },
+      {
+        "title": "Umbraco ASP.NET Developer"
+      }
     ]
   },
   {
@@ -121,13 +173,27 @@
       "longitude": -75.1449277143
     },
     "positions": [
-      "Android Developer",
-      "Cloud Operations Engineer",
-      "iOS Developer",
-      "Java Engineer",
-      "Senior Software Engineer",
-      "Software Architect",
-      "Software Project Manager"
+      {
+        "title": "Android Developer"
+      },
+      {
+        "title": "Cloud Operations Engineer"
+      },
+      {
+        "title": "iOS Developer"
+      },
+      {
+        "title": "Java Engineer"
+      },
+      {
+        "title": "Senior Software Engineer"
+      },
+      {
+        "title": "Software Architect"
+      },
+      {
+        "title": "Software Project Manager"
+      }
     ]
   },
   {
@@ -139,11 +205,21 @@
       "longitude": -75.222586
     },
     "positions": [
-      "Front End Engineer",
-      "Senior Android Engineer",
-      "Senior Operations Engineer",
-      "Senior Software Engineer",
-      "Technical Project Manager"
+      {
+        "title": "Front End Engineer"
+      },
+      {
+        "title": "Senior Android Engineer"
+      },
+      {
+        "title": "Senior Operations Engineer"
+      },
+      {
+        "title": "Senior Software Engineer"
+      },
+      {
+        "title": "Technical Project Manager"
+      }
     ]
   },
   {
@@ -155,7 +231,9 @@
       "longitude": -75.1583954412
     },
     "positions": [
-      "Operations Engineer"
+      {
+        "title": "Operations Engineer"
+      }
     ]
   },
   {
@@ -167,7 +245,9 @@
       "longitude": -75.143379125
     },
     "positions": [
-      "Groovy designer needed!"
+      {
+        "title": "Groovy designer needed!"
+      }
     ]
   },
   {
@@ -179,7 +259,9 @@
       "longitude": -75.165939
     },
     "positions": [
-      "Freelance Developers"
+      {
+        "title": "Freelance Developers"
+      }
     ]
   },
   {
@@ -201,10 +283,18 @@
       "longitude": -75.1392843333
     },
     "positions": [
-      "iOS Developer",
-      "Creative Developer",
-      "Designer",
-      "Senior Interactive Designer"
+      {
+        "title": "iOS Developer"
+      },
+      {
+        "title": "Creative Developer"
+      },
+      {
+        "title": "Designer"
+      },
+      {
+        "title": "Senior Interactive Designer"
+      }
     ]
   },
   {
@@ -216,11 +306,21 @@
       "longitude": -75.456169
     },
     "positions": [
-      "Software Develoment Engineer",
-      "Software Engineer Director",
-      "Software Engineer Java",
-      "Software Engineer Java",
-      "Software QA Staff Engineer"
+      {
+        "title": "Software Develoment Engineer"
+      },
+      {
+        "title": "Software Engineer Director"
+      },
+      {
+        "title": "Software Engineer Java"
+      },
+      {
+        "title": "Software Engineer Java"
+      },
+      {
+        "title": "Software QA Staff Engineer"
+      }
     ]
   },
   {
@@ -232,10 +332,18 @@
       "longitude": -75.158654
     },
     "positions": [
-      "Senior Product Development Engineer",
-      "Interaction Designer",
-      "Software/Firmware Developer",
-      "Product Development Engineer"
+      {
+        "title": "Senior Product Development Engineer"
+      },
+      {
+        "title": "Interaction Designer"
+      },
+      {
+        "title": "Software/Firmware Developer"
+      },
+      {
+        "title": "Product Development Engineer"
+      }
     ]
   },
   {
@@ -247,8 +355,12 @@
       "longitude": -75.1301983333
     },
     "positions": [
-      "Senior iOS Developer",
-      "Senior Android Developer"
+      {
+        "title": "Senior iOS Developer"
+      },
+      {
+        "title": "Senior Android Developer"
+      }
     ]
   },
   {
@@ -270,9 +382,15 @@
       "longitude": -75.19331115
     },
     "positions": [
-      "Lead Firmware Engineer",
-      "Firmware Developer",
-      "Cross-Platform Developer"
+      {
+        "title": "Lead Firmware Engineer"
+      },
+      {
+        "title": "Firmware Developer"
+      },
+      {
+        "title": "Cross-Platform Developer"
+      }
     ]
   },
   {
@@ -284,13 +402,27 @@
       "longitude": -75.399611
     },
     "positions": [
-      "SAP ERP Developer",
-      "Technical Project Manager",
-      "Product Content Coordinator",
-      "Business Intelligence Data Analyst",
-      "Software Engineer (Java)",
-      "JavaScript Developer",
-      "Senior Java Software Engineer"
+      {
+        "title": "SAP ERP Developer"
+      },
+      {
+        "title": "Technical Project Manager"
+      },
+      {
+        "title": "Product Content Coordinator"
+      },
+      {
+        "title": "Business Intelligence Data Analyst"
+      },
+      {
+        "title": "Software Engineer (Java)"
+      },
+      {
+        "title": "JavaScript Developer"
+      },
+      {
+        "title": "Senior Java Software Engineer"
+      }
     ]
   },
   {
@@ -302,9 +434,15 @@
       "longitude": -75.2061795
     },
     "positions": [
-      "Scala Developers",
-      "Sr. Java/Spring Developers",
-      "Mobile Developers"
+      {
+        "title": "Scala Developers"
+      },
+      {
+        "title": "Sr. Java/Spring Developers"
+      },
+      {
+        "title": "Mobile Developers"
+      }
     ]
   },
   {
@@ -336,9 +474,15 @@
       "longitude": -75.1689862653
     },
     "positions": [
-      "Solutions Engineer",
-      "Full Stack Software Engineer – Java",
-      "DevOps Engineer"
+      {
+        "title": "Solutions Engineer"
+      },
+      {
+        "title": "Full Stack Software Engineer – Java"
+      },
+      {
+        "title": "DevOps Engineer"
+      }
     ]
   },
   {
@@ -350,7 +494,9 @@
       "longitude": -75.1628294
     },
     "positions": [
-      "Senior Interaction Designer"
+      {
+        "title": "Senior Interaction Designer"
+      }
     ]
   },
   {
@@ -362,9 +508,15 @@
       "longitude": -75.1671930612
     },
     "positions": [
-      "Senior Java Sofware Engineer",
-      "Front End Web Developer",
-      "Software Engineer"
+      {
+        "title": "Senior Java Sofware Engineer"
+      },
+      {
+        "title": "Front End Web Developer"
+      },
+      {
+        "title": "Software Engineer"
+      }
     ]
   },
   {
@@ -376,8 +528,12 @@
       "longitude": -75.2278333396
     },
     "positions": [
-      "SENIOR DATA SCIENTIST",
-      "PRODUCT MANAGER"
+      {
+        "title": "SENIOR DATA SCIENTIST"
+      },
+      {
+        "title": "PRODUCT MANAGER"
+      }
     ]
   },
   {
@@ -389,11 +545,21 @@
       "longitude": -75.179508
     },
     "positions": [
-      "Product Manager",
-      "UX Designer",
-      "DevOps Engineer",
-      "Front End (Solutions) Engineer",
-      "Software Engineer"
+      {
+        "title": "Product Manager"
+      },
+      {
+        "title": "UX Designer"
+      },
+      {
+        "title": "DevOps Engineer"
+      },
+      {
+        "title": "Front End (Solutions) Engineer"
+      },
+      {
+        "title": "Software Engineer"
+      }
     ]
   },
   {
@@ -405,11 +571,21 @@
       "longitude": -75.2300390769
     },
     "positions": [
-      "Copywriter",
-      "Designer",
-      "Front-End Developer",
-      "Project Manager",
-      "PHP Developer"
+      {
+        "title": "Copywriter"
+      },
+      {
+        "title": "Designer"
+      },
+      {
+        "title": "Front-End Developer"
+      },
+      {
+        "title": "Project Manager"
+      },
+      {
+        "title": "PHP Developer"
+      }
     ]
   },
   {
@@ -421,23 +597,41 @@
       "longitude": -75.217571
     },
     "positions": [
-      "Technical Project Manager",
-      "Quality Assurance (QA) & Digital Production Manager",
-      "Senior Solution Architect",
-      "Sitecore Web Developer",
-      "Technical Lead - Web Development",
-      "Web Developer / Software Engineer (.NET)"
+      {
+        "title": "Technical Project Manager"
+      },
+      {
+        "title": "Quality Assurance (QA) & Digital Production Manager"
+      },
+      {
+        "title": "Senior Solution Architect"
+      },
+      {
+        "title": "Sitecore Web Developer"
+      },
+      {
+        "title": "Technical Lead - Web Development"
+      },
+      {
+        "title": "Web Developer / Software Engineer (.NET)"
+      }
     ]
   },
   {
     "company": "Diagnostic Driving",
-    "contact": { name: "Venk Kandadai", email: "venkkandadai@gmail.com" },
+    "contact": {
+      "name": "Venk Kandadai",
+      "email": "venkkandadai@gmail.com"
+    },
     "positions": [
-      "VP of Engineering - Leadership+Technical ",
-      "Senior Engineer - Technical-only"
+      {
+        "title": "VP of Engineering - Leadership+Technical "
+      },
+      {
+        "title": "Senior Engineer - Technical-only"
+      }
     ]
   },
-  }
   {
     "company": "DramaFever",
     "url": "http://www.dramafever.com/company/careers.html",
@@ -447,9 +641,15 @@
       "longitude": -75.1650889796
     },
     "positions": [
-      "Android Developer",
-      "iOS Developer",
-      "Operations Manager"
+      {
+        "title": "Android Developer"
+      },
+      {
+        "title": "iOS Developer"
+      },
+      {
+        "title": "Operations Manager"
+      }
     ]
   },
   {
@@ -461,9 +661,15 @@
       "longitude": -75.168444
     },
     "positions": [
-      "Graphic Designe",
-      "IOS Developer",
-      "Web Developer"
+      {
+        "title": "Graphic Designe"
+      },
+      {
+        "title": "IOS Developer"
+      },
+      {
+        "title": "Web Developer"
+      }
     ]
   },
   {
@@ -475,8 +681,12 @@
       "longitude": -75.125276
     },
     "positions": [
-      "DIGITAL MARKETING COORDINATOR",
-      "DEVELOPER"
+      {
+        "title": "DIGITAL MARKETING COORDINATOR"
+      },
+      {
+        "title": "DEVELOPER"
+      }
     ]
   },
   {
@@ -498,16 +708,36 @@
       "longitude": -75.289722
     },
     "positions": [
-      "Data Services Support Specialist",
-      "Salesforce Developer",
-      "Senior Systems Administrator",
-      "Senior Systems Automation Engineer",
-      "Software Engineer",
-      "Software Engineer-Data Services",
-      "Sr. Windows Systems Administrator",
-      "Technical Support Engineer",
-      "UX/UI Designer",
-      "Web Designer"
+      {
+        "title": "Data Services Support Specialist"
+      },
+      {
+        "title": "Salesforce Developer"
+      },
+      {
+        "title": "Senior Systems Administrator"
+      },
+      {
+        "title": "Senior Systems Automation Engineer"
+      },
+      {
+        "title": "Software Engineer"
+      },
+      {
+        "title": "Software Engineer-Data Services"
+      },
+      {
+        "title": "Sr. Windows Systems Administrator"
+      },
+      {
+        "title": "Technical Support Engineer"
+      },
+      {
+        "title": "UX/UI Designer"
+      },
+      {
+        "title": "Web Designer"
+      }
     ]
   },
   {
@@ -519,8 +749,12 @@
       "longitude": -75.299617
     },
     "positions": [
-      "Senior Project Manager",
-      "Senior Visual Designer"
+      {
+        "title": "Senior Project Manager"
+      },
+      {
+        "title": "Senior Visual Designer"
+      }
     ]
   },
   {
@@ -542,8 +776,12 @@
       "longitude": -75.41092975
     },
     "positions": [
-      "Project Manager",
-      "Platform Engineer, Cloud Computing"
+      {
+        "title": "Project Manager"
+      },
+      {
+        "title": "Platform Engineer, Cloud Computing"
+      }
     ]
   },
   {
@@ -555,7 +793,9 @@
       "longitude": -75.4162122857
     },
     "positions": [
-      "Senior Developer"
+      {
+        "title": "Senior Developer"
+      }
     ]
   },
   {
@@ -567,9 +807,15 @@
       "longitude": -74.915183875
     },
     "positions": [
-      "Copywriter",
-      "Art Director",
-      "Web Developer"
+      {
+        "title": "Copywriter"
+      },
+      {
+        "title": "Art Director"
+      },
+      {
+        "title": "Web Developer"
+      }
     ]
   },
   {
@@ -581,9 +827,15 @@
       "longitude": -75.2038928333
     },
     "positions": [
-      "PHP Web Developer",
-      "User Interface Developer / Designer",
-      "Software Engineer"
+      {
+        "title": "PHP Web Developer"
+      },
+      {
+        "title": "User Interface Developer / Designer"
+      },
+      {
+        "title": "Software Engineer"
+      }
     ]
   },
   {
@@ -591,8 +843,12 @@
     "url": "https://www.govdelivery.com/company/careers/",
     "address": "",
     "positions": [
-      "Front End Develper/Drupal Themer",
-      "Senior Developer"
+      {
+        "title": "Front End Develper/Drupal Themer"
+      },
+      {
+        "title": "Senior Developer"
+      }
     ]
   },
   {
@@ -604,9 +860,15 @@
       "longitude": -75.1946339592
     },
     "positions": [
-      "Biosensor Research and Development Technician",
-      "Database Developer / Programmer",
-      "Senior Semiconductor Device Engineer"
+      {
+        "title": "Biosensor Research and Development Technician"
+      },
+      {
+        "title": "Database Developer / Programmer"
+      },
+      {
+        "title": "Senior Semiconductor Device Engineer"
+      }
     ]
   },
   {
@@ -618,8 +880,12 @@
       "longitude": -75.161949
     },
     "positions": [
-      "Copywriter",
-      "Freelance Designer"
+      {
+        "title": "Copywriter"
+      },
+      {
+        "title": "Freelance Designer"
+      }
     ]
   },
   {
@@ -631,9 +897,15 @@
       "longitude": -75.174298
     },
     "positions": [
-      "Information Systems – Senior Analyst/Manager",
-      "Product Management – Manager",
-      "Professional Services – Implementations Manager"
+      {
+        "title": "Information Systems – Senior Analyst/Manager"
+      },
+      {
+        "title": "Product Management – Manager"
+      },
+      {
+        "title": "Professional Services – Implementations Manager"
+      }
     ]
   },
   {
@@ -645,8 +917,12 @@
       "longitude": -75.2220595102
     },
     "positions": [
-      "User Experience Researcher",
-      "Program Delivery Manager"
+      {
+        "title": "User Experience Researcher"
+      },
+      {
+        "title": "Program Delivery Manager"
+      }
     ]
   },
   {
@@ -658,22 +934,32 @@
       "longitude": -74.9120337959
     },
     "positions": [
-      "PHP Developer – Magento",
-      "WordPress Developer"
+      {
+        "title": "PHP Developer – Magento"
+      },
+      {
+        "title": "WordPress Developer"
+      }
     ]
   },
   {
     "company": "LeadiD",
     "url": "http://www.leadid.com/about-us/join-our-team/open-positions",
     "address": "201 S Maple St, Ambler, PA, 19002",
-     "geo": {
+    "geo": {
       "latitude": 40.1561585849,
       "longitude": -75.2278333396
     },
     "positions": [
-      "Manager/Director - DevOps",
-      "Senior Software Engineer",
-      "Senior Systems Engineer DevOps"
+      {
+        "title": "Manager/Director - DevOps"
+      },
+      {
+        "title": "Senior Software Engineer"
+      },
+      {
+        "title": "Senior Systems Engineer DevOps"
+      }
     ]
   },
   {
@@ -685,8 +971,12 @@
       "longitude": -75.1809156207
     },
     "positions": [
-      "Associate Software Engineer",
-      "Software Engineer (node.js, java, php, aws)"
+      {
+        "title": "Associate Software Engineer"
+      },
+      {
+        "title": "Software Engineer (node.js, java, php, aws)"
+      }
     ]
   },
   {
@@ -698,13 +988,27 @@
       "longitude": -75.265441
     },
     "positions": [
-      ".NET Software Engineer",
-      "Ruby on Rails Developer",
-      "iOS Developer",
-      "Jr iOS Developer",
-      "Sr Android Developer",
-      "Front End Web Designer/Developer",
-      "Embedded Linux Engineer"
+      {
+        "title": ".NET Software Engineer"
+      },
+      {
+        "title": "Ruby on Rails Developer"
+      },
+      {
+        "title": "iOS Developer"
+      },
+      {
+        "title": "Jr iOS Developer"
+      },
+      {
+        "title": "Sr Android Developer"
+      },
+      {
+        "title": "Front End Web Designer/Developer"
+      },
+      {
+        "title": "Embedded Linux Engineer"
+      }
     ]
   },
   {
@@ -716,10 +1020,18 @@
       "longitude": -75.4241920791
     },
     "positions": [
-      "Director, Data Management",
-      "Program Manager",
-      "Product Manager",
-      "Senior Software Developer (Java)"
+      {
+        "title": "Director, Data Management"
+      },
+      {
+        "title": "Program Manager"
+      },
+      {
+        "title": "Product Manager"
+      },
+      {
+        "title": "Senior Software Developer (Java)"
+      }
     ]
   },
   {
@@ -731,12 +1043,24 @@
       "longitude": -75.131903
     },
     "positions": [
-      "Software Architect, API New Hope, PA, United States",
-      "Sr. Android Engineer / Architect New Hope, PA, United States",
-      "Sr. iOS Developer / Architect New Hope, PA, United States",
-      "Sr. Software Developer (API) New Hope, PA, United States",
-      "DevOps Engineer (Remote) New Hope, PA, United States",
-      "QA Developer (Automation)"
+      {
+        "title": "Software Architect, API New Hope, PA, United States"
+      },
+      {
+        "title": "Sr. Android Engineer / Architect New Hope, PA, United States"
+      },
+      {
+        "title": "Sr. iOS Developer / Architect New Hope, PA, United States"
+      },
+      {
+        "title": "Sr. Software Developer (API) New Hope, PA, United States"
+      },
+      {
+        "title": "DevOps Engineer (Remote) New Hope, PA, United States"
+      },
+      {
+        "title": "QA Developer (Automation)"
+      }
     ]
   },
   {
@@ -748,11 +1072,21 @@
       "longitude": -75.1946339592
     },
     "positions": [
-      "iOS Developer",
-      "Ruby Developer",
-      "iOS Developer – Intern/Co-Op",
-      "Ruby Developer – Intern/Co-Op",
-      "UI/UX Design – Intern/Co-Op"
+      {
+        "title": "iOS Developer"
+      },
+      {
+        "title": "Ruby Developer"
+      },
+      {
+        "title": "iOS Developer – Intern/Co-Op"
+      },
+      {
+        "title": "Ruby Developer – Intern/Co-Op"
+      },
+      {
+        "title": "UI/UX Design – Intern/Co-Op"
+      }
     ]
   },
   {
@@ -774,13 +1108,27 @@
       "longitude": -75.1638900816
     },
     "positions": [
-      "GRAPHIC DESIGNER",
-      "COPYWRITER",
-      "PROOFREADER/RESEARCH",
-      "FRONT END WEB DEVELOPER",
-      "JUNIOR BACK END DEVELOPER",
-      "BACK END DEVELOPER",
-      "SOFTWARE PROJECT MANAGER"
+      {
+        "title": "GRAPHIC DESIGNER"
+      },
+      {
+        "title": "COPYWRITER"
+      },
+      {
+        "title": "PROOFREADER/RESEARCH"
+      },
+      {
+        "title": "FRONT END WEB DEVELOPER"
+      },
+      {
+        "title": "JUNIOR BACK END DEVELOPER"
+      },
+      {
+        "title": "BACK END DEVELOPER"
+      },
+      {
+        "title": "SOFTWARE PROJECT MANAGER"
+      }
     ]
   },
   {
@@ -792,7 +1140,9 @@
       "longitude": -75.5168733857
     },
     "positions": [
-      "Embedded Software Engineers"
+      {
+        "title": "Embedded Software Engineers"
+      }
     ]
   },
   {
@@ -804,10 +1154,18 @@
       "longitude": -75.2904890204
     },
     "positions": [
-      "Director of Delivery Engineering",
-      "Web Developer",
-      "Product Manager",
-      "DevOps Engineer"
+      {
+        "title": "Director of Delivery Engineering"
+      },
+      {
+        "title": "Web Developer"
+      },
+      {
+        "title": "Product Manager"
+      },
+      {
+        "title": "DevOps Engineer"
+      }
     ]
   },
   {
@@ -819,10 +1177,18 @@
       "longitude": -75.168444
     },
     "positions": [
-      "640BR Manager of IT Infrastructure Engineering",
-      "630BR Director of Application Development",
-      "628BR User Experience Designer",
-      "365BR Business Intelligence Engineer"
+      {
+        "title": "640BR Manager of IT Infrastructure Engineering"
+      },
+      {
+        "title": "630BR Director of Application Development"
+      },
+      {
+        "title": "628BR User Experience Designer"
+      },
+      {
+        "title": "365BR Business Intelligence Engineer"
+      }
     ]
   },
   {
@@ -844,8 +1210,12 @@
       "longitude": -75.171593
     },
     "positions": [
-      "Product Management Sr Spec",
-      "Project Manager US Equities Group"
+      {
+        "title": "Product Management Sr Spec"
+      },
+      {
+        "title": "Project Manager US Equities Group"
+      }
     ]
   },
   {
@@ -867,15 +1237,33 @@
       "longitude": -75.1450802
     },
     "positions": [
-      "Interactive Visual Designer",
-      "Information Architect",
-      "Senior Web Business/Systems Analyst",
-      "Senior Project Manager",
-      "Lead Front-End Developer",
-      ".NET Web Application Developer",
-      "Senior .NET Web Application Developer (Sitecore)",
-      "Drupal CMS Developer",
-      "Senior MEAN Stack Developer"
+      {
+        "title": "Interactive Visual Designer"
+      },
+      {
+        "title": "Information Architect"
+      },
+      {
+        "title": "Senior Web Business/Systems Analyst"
+      },
+      {
+        "title": "Senior Project Manager"
+      },
+      {
+        "title": "Lead Front-End Developer"
+      },
+      {
+        "title": ".NET Web Application Developer"
+      },
+      {
+        "title": "Senior .NET Web Application Developer (Sitecore)"
+      },
+      {
+        "title": "Drupal CMS Developer"
+      },
+      {
+        "title": "Senior MEAN Stack Developer"
+      }
     ]
   },
   {
@@ -887,9 +1275,15 @@
       "longitude": -75.1518336122
     },
     "positions": [
-      "Web Developer Full-Stack",
-      "Interactive Developer",
-      "Digital Project Manager"
+      {
+        "title": "Web Developer Full-Stack"
+      },
+      {
+        "title": "Interactive Developer"
+      },
+      {
+        "title": "Digital Project Manager"
+      }
     ]
   },
   {
@@ -901,7 +1295,9 @@
       "longitude": -75.0858912041
     },
     "positions": [
-      "Developer"
+      {
+        "title": "Developer"
+      }
     ]
   },
   {
@@ -913,12 +1309,24 @@
       "longitude": -75.1398402553
     },
     "positions": [
-      "PROJECT MANAGER",
-      "LEAD UI / UX DESIGNER",
-      "IOS DEVELOPER",
-      "FULL STACK JAVASCRIPT DEVELOPER",
-      "FRONT-END DEVELOPER",
-      "WEB PROGRAMMER"
+      {
+        "title": "PROJECT MANAGER"
+      },
+      {
+        "title": "LEAD UI / UX DESIGNER"
+      },
+      {
+        "title": "IOS DEVELOPER"
+      },
+      {
+        "title": "FULL STACK JAVASCRIPT DEVELOPER"
+      },
+      {
+        "title": "FRONT-END DEVELOPER"
+      },
+      {
+        "title": "WEB PROGRAMMER"
+      }
     ]
   },
   {
@@ -930,10 +1338,18 @@
       "longitude": -75.4137162727
     },
     "positions": [
-      "Sr. Java Programmer",
-      "PHP zend developer",
-      "Sr. Magento Developer",
-      "Senior Engineer"
+      {
+        "title": "Sr. Java Programmer"
+      },
+      {
+        "title": "PHP zend developer"
+      },
+      {
+        "title": "Sr. Magento Developer"
+      },
+      {
+        "title": "Senior Engineer"
+      }
     ]
   },
   {
@@ -950,12 +1366,14 @@
     "company": "Pedrera Philadelphia Web Development",
     "url": "http://pedrera.com/about-us/careers",
     "address": "100 Mechanics Street, Doylestown, PA 18901",
-     "geo": {
+    "geo": {
       "latitude": 40.3136617818,
       "longitude": -75.1289168909
     },
     "positions": [
-      "Web Developer"
+      {
+        "title": "Web Developer"
+      }
     ]
   },
   {
@@ -982,12 +1400,14 @@
     "company": "Philly Marketing Labs",
     "url": "http://www.phillymarketinglabs.com/join-our-team/",
     "address": "224 Lansdowne Ave, Wayne, PA 19087",
-     "geo": {
+    "geo": {
       "latitude": 40.040375898,
       "longitude": -75.3892247755
     },
     "positions": [
-      "Web Marketing Project Manager"
+      {
+        "title": "Web Marketing Project Manager"
+      }
     ]
   },
   {
@@ -999,9 +1419,15 @@
       "longitude": -75.1790956
     },
     "positions": [
-      "Software Engineer",
-      "Data Engineer",
-      "Data Scientist"
+      {
+        "title": "Software Engineer"
+      },
+      {
+        "title": "Data Engineer"
+      },
+      {
+        "title": "Data Scientist"
+      }
     ]
   },
   {
@@ -1013,8 +1439,12 @@
       "longitude": -75.4230364054
     },
     "positions": [
-      "Senior Product Manager",
-      "QA Analyst"
+      {
+        "title": "Senior Product Manager"
+      },
+      {
+        "title": "QA Analyst"
+      }
     ]
   },
   {
@@ -1031,14 +1461,20 @@
     "company": "Plum Analytics",
     "url": "http://plumanalytics.com/about/careers/",
     "address": "808 Firethorn Circle, Dresher PA 19025",
-     "geo": {
+    "geo": {
       "latitude": 40.1518441224,
       "longitude": -75.1554711633
     },
     "positions": [
-      "Senior Engineer / Architect (Big Data)",
-      "Mid-Level Engineer (Data Acquisition)",
-      "Mid-level Java Engineer"
+      {
+        "title": "Senior Engineer / Architect (Big Data)"
+      },
+      {
+        "title": "Mid-Level Engineer (Data Acquisition)"
+      },
+      {
+        "title": "Mid-level Java Engineer"
+      }
     ]
   },
   {
@@ -1050,9 +1486,15 @@
       "longitude": -75.1603696122
     },
     "positions": [
-      "Senior Software Engineer",
-      "Software Engineer",
-      "Senior Front-end Engineer"
+      {
+        "title": "Senior Software Engineer"
+      },
+      {
+        "title": "Software Engineer"
+      },
+      {
+        "title": "Senior Front-end Engineer"
+      }
     ]
   },
   {
@@ -1064,7 +1506,9 @@
       "longitude": -75.191464
     },
     "positions": [
-      "Senior Software Developer"
+      {
+        "title": "Senior Software Developer"
+      }
     ]
   },
   {
@@ -1076,19 +1520,23 @@
       "longitude": -75.1578163143
     },
     "positions": [
-      "Designer"
+      {
+        "title": "Designer"
+      }
     ]
   },
   {
     "company": "Push10 Design",
     "url": "http://www.push10.com/blog/",
     "address": "125 NORTH 3RD ST, PHILA. PA 19106",
-     "geo": {
+    "geo": {
       "latitude": 39.9528668,
       "longitude": -75.1450802
     },
     "positions": [
-      "WordPress Developer"
+      {
+        "title": "WordPress Developer"
+      }
     ]
   },
   {
@@ -1110,12 +1558,24 @@
       "longitude": -75.528712
     },
     "positions": [
-      "SharePoint Contractor",
-      "Sitecore Developer",
-      "BI and Data Warehouse Specialist",
-      "Cloud Developer Architect",
-      "Senior SharePoint Engineer",
-      "Cloud Developer Architect Contractor"
+      {
+        "title": "SharePoint Contractor"
+      },
+      {
+        "title": "Sitecore Developer"
+      },
+      {
+        "title": "BI and Data Warehouse Specialist"
+      },
+      {
+        "title": "Cloud Developer Architect"
+      },
+      {
+        "title": "Senior SharePoint Engineer"
+      },
+      {
+        "title": "Cloud Developer Architect Contractor"
+      }
     ]
   },
   {
@@ -1127,7 +1587,9 @@
       "longitude": -75.283746
     },
     "positions": [
-      "APP DEVELOPER"
+      {
+        "title": "APP DEVELOPER"
+      }
     ]
   },
   {
@@ -1139,8 +1601,12 @@
       "longitude": -75.388683
     },
     "positions": [
-      "Senior Client Project Manager",
-      "Software Engineer"
+      {
+        "title": "Senior Client Project Manager"
+      },
+      {
+        "title": "Software Engineer"
+      }
     ]
   },
   {
@@ -1152,9 +1618,15 @@
       "longitude": -75.187326
     },
     "positions": [
-      "Web Developer",
-      "Technical Project Manager",
-      "Senior Product Designer"
+      {
+        "title": "Web Developer"
+      },
+      {
+        "title": "Technical Project Manager"
+      },
+      {
+        "title": "Senior Product Designer"
+      }
     ]
   },
   {
@@ -1166,8 +1638,12 @@
       "longitude": -75.1809156207
     },
     "positions": [
-      "Software Engineer, Java",
-      "Software Engineer, Java + Ruby"
+      {
+        "title": "Software Engineer, Java"
+      },
+      {
+        "title": "Software Engineer, Java + Ruby"
+      }
     ]
   },
   {
@@ -1179,10 +1655,18 @@
       "longitude": -75.1629786667
     },
     "positions": [
-      "Director of Infrmation Security",
-      "Security Engineer",
-      "Senior Web Applications Engineer",
-      "Software Engineer"
+      {
+        "title": "Director of Infrmation Security"
+      },
+      {
+        "title": "Security Engineer"
+      },
+      {
+        "title": "Senior Web Applications Engineer"
+      },
+      {
+        "title": "Software Engineer"
+      }
     ]
   },
   {
@@ -1194,9 +1678,15 @@
       "longitude": -75.2902143333
     },
     "positions": [
-      "Data Architect",
-      "Data Migration Specialist",
-      "Senior Project Manager"
+      {
+        "title": "Data Architect"
+      },
+      {
+        "title": "Data Migration Specialist"
+      },
+      {
+        "title": "Senior Project Manager"
+      }
     ]
   },
   {
@@ -1208,7 +1698,9 @@
       "longitude": -75.45604168
     },
     "positions": [
-      "Software Developer"
+      {
+        "title": "Software Developer"
+      }
     ]
   },
   {
@@ -1230,10 +1722,18 @@
       "longitude": -75.161949
     },
     "positions": [
-      "Client Service Operations Manager",
-      "Data Scientist",
-      "Sr. Front End Engineer",
-      "Sr. Product Engineer"
+      {
+        "title": "Client Service Operations Manager"
+      },
+      {
+        "title": "Data Scientist"
+      },
+      {
+        "title": "Sr. Front End Engineer"
+      },
+      {
+        "title": "Sr. Product Engineer"
+      }
     ]
   },
   {
@@ -1245,7 +1745,9 @@
       "longitude": -75.161868
     },
     "positions": [
-      "Product Designer (Android)"
+      {
+        "title": "Product Designer (Android)"
+      }
     ]
   },
   {
@@ -1263,10 +1765,18 @@
     "url": "http://financialsystemsjobs.sungard.com/search/advanced-search/ASCategory/-1/SPostedDate/-1/ASCountry/-1/ASState/-1/ASCity/Philadelphia/ASLocation/-1/ASCompanyName/-1/ASCustom1/-1/ASCustom2/-1/ASCustom3/-1/ASCustom4/-1/ASCustom5/-1/SIsRadius/false/ASCityStateZipcode/-1/ASDistance/-1/ASLatitude/-1/ASLongitude/-1/ASDistanceType/-1",
     "address": "",
     "positions": [
-      "Core Java Development Engineer",
-      "Sr. Android developer",
-      "Sr. Lead Java developer",
-      "Sr. Core Java developer"
+      {
+        "title": "Core Java Development Engineer"
+      },
+      {
+        "title": "Sr. Android developer"
+      },
+      {
+        "title": "Sr. Lead Java developer"
+      },
+      {
+        "title": "Sr. Core Java developer"
+      }
     ]
   },
   {
@@ -1288,10 +1798,18 @@
       "longitude": -75.305449
     },
     "positions": [
-      "Development Lead",
-      "Senior Web Developer",
-      "Web Developer",
-      "Experience Designer- Contractor"
+      {
+        "title": "Development Lead"
+      },
+      {
+        "title": "Senior Web Developer"
+      },
+      {
+        "title": "Web Developer"
+      },
+      {
+        "title": "Experience Designer- Contractor"
+      }
     ]
   },
   {
@@ -1303,11 +1821,21 @@
       "longitude": -75.163112
     },
     "positions": [
-      "Senior Program Manager",
-      "Technology Consultant",
-      "Lead Full-Stack Engineer",
-      "API Engineer",
-      "Technical Solutions Architect"
+      {
+        "title": "Senior Program Manager"
+      },
+      {
+        "title": "Technology Consultant"
+      },
+      {
+        "title": "Lead Full-Stack Engineer"
+      },
+      {
+        "title": "API Engineer"
+      },
+      {
+        "title": "Technical Solutions Architect"
+      }
     ]
   },
   {
@@ -1319,8 +1847,12 @@
       "longitude": -75.179508
     },
     "positions": [
-      "Development Director, Mobile",
-      "iOS Developer"
+      {
+        "title": "Development Director, Mobile"
+      },
+      {
+        "title": "iOS Developer"
+      }
     ]
   },
   {
@@ -1342,10 +1874,18 @@
       "longitude": -74.937063
     },
     "positions": [
-      "Experience Design Lead",
-      "Mobile Developers - Android & iOS",
-      "Ruby on Rails Developer",
-      "Senior User Experience Designer (UX)"
+      {
+        "title": "Experience Design Lead"
+      },
+      {
+        "title": "Mobile Developers - Android & iOS"
+      },
+      {
+        "title": "Ruby on Rails Developer"
+      },
+      {
+        "title": "Senior User Experience Designer (UX)"
+      }
     ]
   },
   {
@@ -1357,8 +1897,12 @@
       "longitude": -75.306129102
     },
     "positions": [
-      "Front-End / UI Developer",
-      "iOS Developer"
+      {
+        "title": "Front-End / UI Developer"
+      },
+      {
+        "title": "iOS Developer"
+      }
     ]
   },
   {
@@ -1370,9 +1914,15 @@
       "longitude": -75.203371
     },
     "positions": [
-      "Ruby on Rails Lead Programmer",
-      "Web Developer",
-      "Project Manager"
+      {
+        "title": "Ruby on Rails Lead Programmer"
+      },
+      {
+        "title": "Web Developer"
+      },
+      {
+        "title": "Project Manager"
+      }
     ]
   },
   {
@@ -1384,7 +1934,9 @@
       "longitude": -75.1686654651
     },
     "positions": [
-      "Software Engineer"
+      {
+        "title": "Software Engineer"
+      }
     ]
   },
   {
@@ -1396,9 +1948,15 @@
       "longitude": -75.1457715
     },
     "positions": [
-      "Quality Assurance Manager",
-      "Ruby On Rails Developer",
-      "Sr. Visual Designer"
+      {
+        "title": "Quality Assurance Manager"
+      },
+      {
+        "title": "Ruby On Rails Developer"
+      },
+      {
+        "title": "Sr. Visual Designer"
+      }
     ]
   },
   {
@@ -1410,8 +1968,12 @@
       "longitude": -75.1455902857
     },
     "positions": [
-      "Senior C# Developer",
-      "Quality Assurance Engineer"
+      {
+        "title": "Senior C# Developer"
+      },
+      {
+        "title": "Quality Assurance Engineer"
+      }
     ]
   },
   {
@@ -1433,8 +1995,12 @@
       "longitude": -75.255467
     },
     "positions": [
-      "Software Engineer (All Levels)",
-      "DevOps Engineer"
+      {
+        "title": "Software Engineer (All Levels)"
+      },
+      {
+        "title": "DevOps Engineer"
+      }
     ]
   },
   {
@@ -1446,7 +2012,9 @@
       "longitude": -75.1628294
     },
     "positions": [
-      "Drupal Developers and Themers"
+      {
+        "title": "Drupal Developers and Themers"
+      }
     ]
   },
   {
@@ -1454,10 +2022,18 @@
     "url": "http://www.zoomiinc.com/jobs/",
     "address": "PA",
     "positions": [
-      "ALGORITHM ENGINEER",
-      "SENIOR FRONTEND ENGINEER",
-      "SENIOR SERVER BACKEND ENGINEER",
-      "SENIOR IOS ENGINEER"
+      {
+        "title": "ALGORITHM ENGINEER"
+      },
+      {
+        "title": "SENIOR FRONTEND ENGINEER"
+      },
+      {
+        "title": "SENIOR SERVER BACKEND ENGINEER"
+      },
+      {
+        "title": "SENIOR IOS ENGINEER"
+      }
     ]
   },
   {
@@ -1469,14 +2045,30 @@
       "longitude": -75.5336614375
     },
     "positions": [
-      "UI Designer",
-      "Cloud Services Developer",
-      "DevOps Engineer",
-      "Director of Engineering",
-      "Javascript UI Developer",
-      "Linux Application Developer",
-      "Solutions Support Engineer",
-      "QA Test Engineer"
+      {
+        "title": "UI Designer"
+      },
+      {
+        "title": "Cloud Services Developer"
+      },
+      {
+        "title": "DevOps Engineer"
+      },
+      {
+        "title": "Director of Engineering"
+      },
+      {
+        "title": "Javascript UI Developer"
+      },
+      {
+        "title": "Linux Application Developer"
+      },
+      {
+        "title": "Solutions Support Engineer"
+      },
+      {
+        "title": "QA Test Engineer"
+      }
     ]
   },
   {

--- a/sample.json
+++ b/sample.json
@@ -1,0 +1,24 @@
+[
+  {
+    "company": "Think Brownstone",
+    "url": "https://www.thinkbrownstone.com/careers/",
+    "address": "201 Fayette St, Conshohocken, PA 19428",
+    "geo": {
+      "latitude": 40.074711,
+      "longitude": -75.305449
+    },
+    "positions": [
+      {
+        "title": "Software Engineer",
+        "baseSalary": {
+          "minPrice": 50000,
+          "maxPrice": 70000,
+          "priceCurrency": "USD"
+        },
+        "employmentType": "Internal",
+        "occupationalCategory": "15-1132.00 Software Developers, Application",
+        "skills": "Rails, JavaScript, Git"
+      }
+    ]
+  }
+]

--- a/sample.json
+++ b/sample.json
@@ -1,23 +1,34 @@
 [
   {
-    "company": "Think Brownstone",
-    "url": "https://www.thinkbrownstone.com/careers/",
-    "address": "201 Fayette St, Conshohocken, PA 19428",
+    "company": "PhillyDev",
+    "type": [
+      "Organization"
+    ],
+    "url": "http://phillydev.org/#careers",
+    "address": "Philadelphia, PA",
     "geo": {
-      "latitude": 40.074711,
-      "longitude": -75.305449
+      "_comment": "You can use MyGeoPosition.com (http://mygeoposition.com/) to determine the geolocation for the address.",
+      "@context": "http://schema.org",
+      "@type": "GeoCoordinates",
+      "latitude": 40.07231,
+      "longitude": -75.203371
     },
     "positions": [
       {
-        "title": "Software Engineer",
+        "_comment": "See https://schema.org/JobPosting for more attributes that can be used with a position.",
+        "@context": "http://schema.org",
+        "@type": "JobPosting",
+        "title": "Web Developer",
+        "occupationalCategory": "15-1134.00 Web Developers",
+        "responsibilities": "Design, create, and modify Web sites. Analyze user needs to implement Web site content, graphics, performance, and capacity. May integrate Web sites with other computer applications. May convert written, graphic, audio, and video components to compatible Web formats by using software designed to facilitate the creation of Web and multimedia content.",
+        "skills": "HTML5, CSS3, JavaScript, Git",
         "baseSalary": {
-          "minPrice": 50000,
-          "maxPrice": 70000,
-          "priceCurrency": "USD"
+          "@type": "PriceSpecification",
+          "minPrice": 40000,
+          "maxPrice": 90000
         },
-        "employmentType": "Internal",
-        "occupationalCategory": "15-1132.00 Software Developers, Application",
-        "skills": "Rails, JavaScript, Git"
+        "salaryCurrency": "USD",
+        "employmentType": "Internal"
       }
     ]
   }


### PR DESCRIPTION
Changed “location” to “geo” to follow examples from Schema.org. Hopefully this will prevent namespace collision when multiple locations are implemented. Also changed the positions from strings to objects. This should allow people to include more data about the job. 