### PR TITLE
Data scrape

### DIFF
--- a/companies/needCareerUrl/Advent-Design-Corporation.json
+++ b/companies/needCareerUrl/Advent-Design-Corporation.json
@@ -1,0 +1,11 @@
+{
+  "company": "Advent Design Corporation",
+  "url": "",
+  "webSiteUrl": "http://www.adventdesign.com/",
+  "address": "925 Canal Street, Bristol PA, 19007",
+  "geo": {
+    "latitude": 40.104236,
+    "longitude": -74.851952
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Allturna.json
+++ b/companies/needCareerUrl/Allturna.json
@@ -1,0 +1,11 @@
+{
+  "company": "Allturna",
+  "url": "",
+  "webSiteUrl": "http://www.allturna.com/",
+  "address": "16 North Franklin Street, Suite 115, Doylestown, PA 18901",
+  "geo": {
+    "latitude": 40.308792,
+    "longitude": -75.135166
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Amphetamobile.json
+++ b/companies/needCareerUrl/Amphetamobile.json
@@ -1,0 +1,11 @@
+{
+  "company": "Amphetamobile",
+  "url": "",
+  "webSiteUrl": "http://www.amphetamobile.com/",
+  "address": "30 South 15th Street, 15th Floor, Philadelphia, PA 19102",
+  "geo": {
+    "latitude": 39.951557,
+    "longitude": -75.165854
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Astound.json
+++ b/companies/needCareerUrl/Astound.json
@@ -1,0 +1,11 @@
+{
+  "company": "Astound",
+  "url": "",
+  "webSiteUrl": "http://astoundvirtual.com/",
+  "address": "196 W Ashland St, Doylestown, Pa 18901",
+  "geo": {
+    "latitude": 40.30518,
+    "longitude": -75.132091
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Back-to-Basics-Learning-Dynamics-Inc.json
+++ b/companies/needCareerUrl/Back-to-Basics-Learning-Dynamics-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Back to Basics Learning Dynamics, Inc.",
+  "url": "",
+  "webSiteUrl": "http://backtobasicslearning.com/",
+  "address": "6 Stone Hill Road, Wilmington, DE 19803",
+  "geo": {
+    "latitude": 39.762581,
+    "longitude": -75.551643
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Bear-Staffing-Services-Corp.json
+++ b/companies/needCareerUrl/Bear-Staffing-Services-Corp.json
@@ -1,0 +1,11 @@
+{
+  "company": "Bear Staffing Services Corp",
+  "url": "",
+  "webSiteUrl": "http://www.bearstaff.com/",
+  "address": " 47 S. Broad Street, Woodbury, NJ 08096",
+  "geo": {
+    "latitude": 39.837256,
+    "longitude": -75.154299
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/COLDLIGHT-SOLUTIONS-LLC.json
+++ b/companies/needCareerUrl/COLDLIGHT-SOLUTIONS-LLC.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Not sure about this one, end up at ThingWorx, careers links goto http://www.ptc.com/careers to many redirects for me.",
+  "company": "COLDLIGHT SOLUTIONS, LLC",
+  "url": "",
+  "webSiteUrl": "http://www.coldlight.com/",
+  "address": "Philadelphia, PA",
+  "geo": {
+    "latitude": 39.952584,
+    "longitude": -75.165222
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Careerminds.json
+++ b/companies/needCareerUrl/Careerminds.json
@@ -1,0 +1,11 @@
+{
+  "company": "Careerminds",
+  "url": "",
+  "webSiteUrl": "http://www.careerminds.com/",
+  "address": "1735 Market Street, Suite 2501, Philadelphia, PA 19103",
+  "geo": {
+    "latitude": 39.953633,
+    "longitude": -75.169532
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Cipher-Prime.json
+++ b/companies/needCareerUrl/Cipher-Prime.json
@@ -1,0 +1,11 @@
+{
+  "company": "Cipher Prime",
+  "url": "",
+  "webSiteUrl": "http://www.cipherprime.com/",
+  "address": "239 Chestnut St. Suite 2A, Philadelphia, PA 19106",
+  "geo": {
+    "latitude": 39.9486916879,
+    "longitude": -75.1452889912
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Convergent-Technologies-Inc.json
+++ b/companies/needCareerUrl/Convergent-Technologies-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Convergent Technologies, Inc.",
+  "url": "",
+  "webSiteUrl": "http://team-cti.com/",
+  "address": "600 Swedesford Rd., Suite C, Malvern, PA 19355",
+  "geo": {
+    "latitude": 40.042045,
+    "longitude": -75.576917
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/CreativeMMS.json
+++ b/companies/needCareerUrl/CreativeMMS.json
@@ -1,0 +1,11 @@
+{
+  "company": "CreativeMMS",
+  "url": "",
+  "webSiteUrl": "http://creativemms.com/",
+  "address": "417 N 8th St, #201, Philadelphia, PA 19123",
+  "geo": {
+    "latitude": 39.959084,
+    "longitude": -75.151582
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Dinh-LLC.json
+++ b/companies/needCareerUrl/Dinh-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Dinh LLC",
+  "url": "",
+  "webSiteUrl": "http://www.hdetron.com/",
+  "address": "Philadelphia, PA",
+  "geo": {
+    "latitude": 39.952584,
+    "longitude": -75.165222
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Finit-Solutions.json
+++ b/companies/needCareerUrl/Finit-Solutions.json
@@ -1,0 +1,11 @@
+{
+  "company": "Finit Solutions",
+  "url": "",
+  "webSiteUrl": "http://www.finitsolutions.com/",
+  "address": "103 Chesley Drive, Suite 207, Media, PA 19063",
+  "geo": {
+    "latitude": 39.915406,
+    "longitude": -75.374749
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Fun-and-Function-LLC.json
+++ b/companies/needCareerUrl/Fun-and-Function-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Fun and Function LLC",
+  "url": "",
+  "webSiteUrl": "http://www.funandfunction.com/",
+  "address": "Merion Station, PA 19066",
+  "geo": {
+    "latitude": 39.998214,
+    "longitude": -75.250823
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Futura-Mobility-LLC.json
+++ b/companies/needCareerUrl/Futura-Mobility-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Futura Mobility, LLC",
+  "url": "",
+  "webSiteUrl": "http://www.futuramobility.com/",
+  "address": "515 Pennsylvania Avenue, Fort Washington, PA 19034",
+  "geo": {
+    "latitude": 40.134509,
+    "longitude": -75.20571
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/HealthJump.json
+++ b/companies/needCareerUrl/HealthJump.json
@@ -1,0 +1,11 @@
+{
+  "company": "HealthJump",
+  "url": "",
+  "webSiteUrl": "http://www.healthjump.com/",
+  "address": "400 Franklin Avenue, Suite 124, Phoenixville, PA, 19460",
+  "geo": {
+    "latitude": 40.141547,
+    "longitude": -75.521425
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/ITData-Inc.json
+++ b/companies/needCareerUrl/ITData-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "ITData, Inc.",
+  "url": "",
+  "webSiteUrl": "http://itdata.com/",
+  "address": "8 Penn Center Suite 2110, 1628 JFK Boulevard, Philadelphia, PA 19103",
+  "geo": {
+    "latitude": 39.953705,
+    "longitude": -75.167953
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Information-Assurance-Specialists-Inc.json
+++ b/companies/needCareerUrl/Information-Assurance-Specialists-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Information Assurance Specialists, Inc.",
+  "url": "",
+  "webSiteUrl": "http://www.iaspecialists.com/",
+  "address": "900 Route 168, Suite C4, Turnersville, NJ 08012",
+  "geo": {
+    "latitude": 39.777541,
+    "longitude": -75.052146
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Joseph-Giannone-Plumbing-Heating-and-Air-Conditioning.json
+++ b/companies/needCareerUrl/Joseph-Giannone-Plumbing-Heating-and-Air-Conditioning.json
@@ -1,0 +1,11 @@
+{
+  "company": "Joseph Giannone Plumbing Heating and Air Conditioning",
+  "url": "",
+  "webSiteUrl": "http://www.calljg.com/",
+  "address": "1641 Delmar Drive, Folcroft, PA 19032",
+  "geo": {
+    "latitude": 39.894585,
+    "longitude": -75.277584
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Juno-Search-Partners.json
+++ b/companies/needCareerUrl/Juno-Search-Partners.json
@@ -1,0 +1,11 @@
+{
+  "company": "Juno Search Partners",
+  "url": "",
+  "webSiteUrl": "http://www.junosearchpartners.com/",
+  "address": "1315 Walnut St., Suite 522, Philadelphia, PA 19107",
+  "geo": {
+    "latitude": 39.949591,
+    "longitude": -75.16289
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/KBS-Tax-Service-Inc-DBA-Liberty-Tax-Service-5428.json
+++ b/companies/needCareerUrl/KBS-Tax-Service-Inc-DBA-Liberty-Tax-Service-5428.json
@@ -1,0 +1,11 @@
+{
+  "company": "KBS Tax Service, Inc DBA Liberty Tax Service, #5428",
+  "url": "",
+  "webSiteUrl": "http://www.libertytax.com/",
+  "address": "Philadelphia, PA",
+  "geo": {
+    "latitude": 39.952584,
+    "longitude": -75.165222
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Karma.json
+++ b/companies/needCareerUrl/Karma.json
@@ -1,0 +1,11 @@
+{
+  "company": "Karma",
+  "url": "",
+  "webSiteUrl": "http://karmaagency.com/",
+  "address": "230 South Broad Street, Suite 1500, Philadelphia, PA 19102",
+  "geo": {
+    "latitude": 39.9488036943,
+    "longitude": -75.1645772667
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Liberty-Fox-Technologies-LLC.json
+++ b/companies/needCareerUrl/Liberty-Fox-Technologies-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Liberty Fox Technologies, LLC",
+  "url": "",
+  "webSiteUrl": "http://www.libertyfoxtech.com/",
+  "address": "931 Huntingdon Pike, Huntingdon Valley, PA 19006",
+  "geo": {
+    "latitude": 40.091353,
+    "longitude": -75.092912
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/LifeCycle-Software-Inc.json
+++ b/companies/needCareerUrl/LifeCycle-Software-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "LifeCycle Software, Inc.",
+  "url": "",
+  "webSiteUrl": "http://www.lifecyclesoftware.com/",
+  "address": "820 Alene Rd, Ambler, PA 19002",
+  "geo": {
+    "latitude": 40.172427,
+    "longitude": -75.21579
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Little-Big-IT-Box.json
+++ b/companies/needCareerUrl/Little-Big-IT-Box.json
@@ -1,0 +1,11 @@
+{
+  "company": "Little Big IT Box",
+  "url": "",
+  "webSiteUrl": "http://www.littlebigitbox.com/",
+  "address": "900 Route 168, Suite C4, Turnersville  New Jersey, 08012",
+  "geo": {
+    "latitude": 39.777541,
+    "longitude": -75.052146
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/M-Shop-360.json
+++ b/companies/needCareerUrl/M-Shop-360.json
@@ -1,0 +1,11 @@
+{
+  "company": "M Shop 360",
+  "url": "",
+  "webSiteUrl": "http://mshop360.com/",
+  "address": "450 Parkway Drive, Suite 102, Broomall, PA 19008",
+  "geo": {
+    "latitude": 39.959533,
+    "longitude": -75.343632
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/McGrath-Systems.json
+++ b/companies/needCareerUrl/McGrath-Systems.json
@@ -1,0 +1,11 @@
+{
+  "company": "McGrath Systems",
+  "url": "",
+  "webSiteUrl": "http://www.mcgrathsystems.com/",
+  "address": "1787 Sentry Parkway, West Building 16, Suite 215, Blue Bell, PA 19422",
+  "geo": {
+    "latitude": 40.134891,
+    "longitude": -75.279763
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Message-Agency.json
+++ b/companies/needCareerUrl/Message-Agency.json
@@ -1,0 +1,11 @@
+{
+  "company": "Message Agency",
+  "url": "",
+  "webSiteUrl": "http://messageagency.com/",
+  "address": "417 N 8th St, Suite 204, Philadelphia, PA 19123",
+  "geo": {
+    "latitude": 39.959084,
+    "longitude": -75.151582
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Mighty-Engine.json
+++ b/companies/needCareerUrl/Mighty-Engine.json
@@ -1,0 +1,11 @@
+{
+  "company": "Mighty Engine",
+  "url": "",
+  "webSiteUrl": "http://themightyengine.com/",
+  "address": "219 Cuthbert Street, Suite 600, Philadelphia, PA 19106",
+  "geo": {
+    "latitude": 39.9514325893,
+    "longitude": -75.1435561154
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Mom-Corps.json
+++ b/companies/needCareerUrl/Mom-Corps.json
@@ -1,0 +1,11 @@
+{
+  "company": "Mom Corps",
+  "url": "",
+  "webSiteUrl": "http://www.momcorps.com/",
+  "address": "Philadelphia, PA",
+  "geo": {
+    "latitude": 39.952584,
+    "longitude": -75.165222
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Oncourse-Systems.json
+++ b/companies/needCareerUrl/Oncourse-Systems.json
@@ -1,0 +1,11 @@
+{
+  "company": "Oncourse Systems",
+  "url": "",
+  "webSiteUrl": "https://www.oncoursesystems.com/",
+  "address": "333 Swedesboro Avenue, Gibbstown, NJ 08027",
+  "geo": {
+    "latitude": 39.811212,
+    "longitude": -75.264157
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/OpDecision.json
+++ b/companies/needCareerUrl/OpDecision.json
@@ -1,0 +1,11 @@
+{
+  "company": "OpDecision",
+  "url": "",
+  "webSiteUrl": "http://www.opdecision.com/",
+  "address": "13 John Singer Sargent Way, Marlton, NJ 08053",
+  "geo": {
+    "latitude": 39.80121,
+    "longitude": -74.890253
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Open-Tier-Systems-LLC.json
+++ b/companies/needCareerUrl/Open-Tier-Systems-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Open Tier Systems, LLC",
+  "url": "",
+  "webSiteUrl": "http://www.opentiersystems.com/",
+  "address": "525 Plymouth Road, Suite 316, Plymouth Meeting, PA 19462",
+  "geo": {
+    "latitude": 40.111027,
+    "longitude": -75.295714
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Pathfinders-Inc.json
+++ b/companies/needCareerUrl/Pathfinders-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Pathfinders, Inc.",
+  "url": "",
+  "webSiteUrl": "http://www.pathfindersinc.net/",
+  "address": "308 W. Lancaster Ave., Wayne, PA 19087",
+  "geo": {
+    "latitude": 40.043889,
+    "longitude": -75.394185
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Payroll-Deduct-LLC.json
+++ b/companies/needCareerUrl/Payroll-Deduct-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Payroll Deduct LLC",
+  "url": "",
+  "webSiteUrl": "http://payrollshopping.com/",
+  "address": "1217 Sansom Street, Philadelphia, PA 19107",
+  "geo": {
+    "latitude": 39.949923,
+    "longitude": -75.161334
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Pop-Promos.json
+++ b/companies/needCareerUrl/Pop-Promos.json
@@ -1,0 +1,11 @@
+{
+  "company": "Pop! Promos",
+  "url": "",
+  "webSiteUrl": "http://www.poppromos.com/",
+  "address": "820a South 4th Street, Philadelphia, PA 19147",
+  "geo": {
+    "latitude": 39.937725,
+    "longitude": -75.150222
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/PowerOne.json
+++ b/companies/needCareerUrl/PowerOne.json
@@ -1,0 +1,11 @@
+{
+  "company": "PowerOne",
+  "url": "",
+  "webSiteUrl": "http://poweroneprint.com/",
+  "address": "532 West Market Street, Perkasie, PA 18944",
+  "geo": {
+    "latitude": 40.373387,
+    "longitude": -75.293757
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Quaker-City-Mercantile.json
+++ b/companies/needCareerUrl/Quaker-City-Mercantile.json
@@ -1,0 +1,11 @@
+{
+  "company": "Quaker City Mercantile",
+  "url": "",
+  "webSiteUrl": "http://quakercitymercantile.com/",
+  "address": "114-120 S 13th St, Philadelphia, PA",
+  "geo": {
+    "latitude": 39.9498066501,
+    "longitude": -75.1621059839
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Sides-Media.json
+++ b/companies/needCareerUrl/Sides-Media.json
@@ -1,0 +1,11 @@
+{
+  "company": "Sides Media",
+  "url": "",
+  "webSiteUrl": "http://sidesmedia.com/",
+  "address": "13250 Trevose Rd., Philadelphia, PA 19116",
+  "geo": {
+    "latitude": 40.1265392767,
+    "longitude": -75.012612919
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Streamline-Solutions-LLC.json
+++ b/companies/needCareerUrl/Streamline-Solutions-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Streamline Solutions, LLC",
+  "url": "",
+  "webSiteUrl": "http://www.streamlinephilly.com/",
+  "address": "2301 Washington Ave, Ste. 111, Philadelphia, PA 19146",
+  "geo": {
+    "latitude": 39.940089,
+    "longitude": -75.182754
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/SuperFriendly.json
+++ b/companies/needCareerUrl/SuperFriendly.json
@@ -1,0 +1,11 @@
+{
+  "company": "SuperFriendly",
+  "url": "",
+  "webSiteUrl": "http://superfriend.ly/",
+  "address": "Philadelphia, PA",
+  "geo": {
+    "latitude": 40.07231,
+    "longitude": -75.203371
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/TITAN-Mobile-Shredding-LLC.json
+++ b/companies/needCareerUrl/TITAN-Mobile-Shredding-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "TITAN Mobile Shredding, LLC.",
+  "url": "",
+  "webSiteUrl": "http://www.titanshredding.com/",
+  "address": "6110 Kit Road, Pipersville, PA 18947",
+  "geo": {
+    "latitude": 40.398453,
+    "longitude": -75.148933
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Thanhauser-Computer-Services-LLC.json
+++ b/companies/needCareerUrl/Thanhauser-Computer-Services-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Thanhauser Computer Services, LLC",
+  "url": "",
+  "webSiteUrl": "http://www.tcstechsupport.net/",
+  "address": "21 Village Center Drive, Unit C-1, Reading, PA 19607",
+  "geo": {
+    "latitude": 40.281349,
+    "longitude": -75.922228
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/The-Carney-Group.json
+++ b/companies/needCareerUrl/The-Carney-Group.json
@@ -1,0 +1,11 @@
+{
+  "company": "The Carney Group",
+  "url": "",
+  "webSiteUrl": "http://www.carneyjobs.com/",
+  "address": "925 Harvest Drive, Suite 240, Blue Bell, PA  19422",
+  "geo": {
+    "latitude": 40.152258,
+    "longitude": -75.284994
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/The-Rox-Group.json
+++ b/companies/needCareerUrl/The-Rox-Group.json
@@ -1,0 +1,11 @@
+{
+  "company": "The Rox Group",
+  "url": "",
+  "webSiteUrl": "http://www.rtacabinetstore.com/",
+  "address": "6 Union Hill Road, Conshohocken, PA 19428",
+  "geo": {
+    "latitude": 40.068333,
+    "longitude": -75.322778
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/The-School-District-of-Philadelphia.json
+++ b/companies/needCareerUrl/The-School-District-of-Philadelphia.json
@@ -1,0 +1,11 @@
+{
+  "company": "The School District of Philadelphia",
+  "url": "",
+  "webSiteUrl": "http://www.phila.k12.pa.us/",
+  "address": "Philadelphia, PA",
+  "geo": {
+    "latitude": 39.952584,
+    "longitude": -75.165222
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Total-Technology-Resources.json
+++ b/companies/needCareerUrl/Total-Technology-Resources.json
@@ -1,0 +1,11 @@
+{
+  "company": "Total Technology Resources",
+  "url": "",
+  "webSiteUrl": "http://www.thetechresource.com/",
+  "address": "10063 Sandmeyer Lane, Suite 100, Philadelphia, PA 19116",
+  "geo": {
+    "latitude": 40.112974,
+    "longitude": -75.033802
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Trinity-Packaging-Supply.json
+++ b/companies/needCareerUrl/Trinity-Packaging-Supply.json
@@ -1,0 +1,11 @@
+{
+  "company": "Trinity Packaging Supply",
+  "url": "",
+  "webSiteUrl": "http://www.trinitypackagingsupply.com/",
+  "address": "1010 Haddonfield Berlin Rd, Ste 405, Voorhees, NJ 08043",
+  "geo": {
+    "latitude": 39.849122,
+    "longitude": -74.977163
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Veterinary-Practice-Partners.json
+++ b/companies/needCareerUrl/Veterinary-Practice-Partners.json
@@ -1,0 +1,11 @@
+{
+  "company": "Veterinary Practice Partners",
+  "url": "",
+  "webSiteUrl": "http://www.vetpartners.com/",
+  "address": "601 S. Henderson Rd, Ste 155, King of Prussia, PA 19406-4234",
+  "geo": {
+    "latitude": 40.078644,
+    "longitude": -75.356695
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/VoxNet-LLC.json
+++ b/companies/needCareerUrl/VoxNet-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "VoxNet, LLC",
+  "url": "",
+  "webSiteUrl": "http://www.voxnetinc.com/",
+  "address": "400 Davis Drive, Suite 100, Plymouth Meeting, PA 19462",
+  "geo": {
+    "latitude": 40.107164,
+    "longitude": -75.297432
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/Webjunto.json
+++ b/companies/needCareerUrl/Webjunto.json
@@ -1,0 +1,11 @@
+{
+  "company": "Webjunto",
+  "url": "",
+  "webSiteUrl": "http://webjunto.com/",
+  "address": "1040 N. 2nd Street, Suite 301, Philadelphia, PA 19123",
+  "geo": {
+    "latitude": 39.967349,
+    "longitude": -75.140434
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/edtell-LLC.json
+++ b/companies/needCareerUrl/edtell-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "edtell LLC",
+  "url": "",
+  "webSiteUrl": "http://www.edtell.com/",
+  "address": "550 State Road, Suite 115, Bensalem, PA 19020",
+  "geo": {
+    "latitude": 40.059548,
+    "longitude": -74.974989
+  },
+  "positions": []
+}

--- a/companies/needCareerUrl/s2s-Communications.json
+++ b/companies/needCareerUrl/s2s-Communications.json
@@ -1,0 +1,11 @@
+{
+  "company": "s2s Communications",
+  "url": "",
+  "webSiteUrl": "http://www.s2scommunications.com/",
+  "address": "3000 Atrium Way, Suite 530, Mount Laurel, NJ 08054",
+  "geo": {
+    "latitude": 39.917877,
+    "longitude": -74.949185
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Alliance-Pharma-Inc.json
+++ b/companies/underConsideration/Alliance-Pharma-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Alliance Pharma, Inc.",
+  "url": "http://www.alliancepharmaco.com/company/careers/",
+  "webSiteUrl": "http://www.alliancepharmaco.com/",
+  "address": "17 Lee Boulevard, Malvern, PA 19355",
+  "geo": {
+    "latitude": 40.069581,
+    "longitude": -75.550956
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Big-Sky-Enterprises.json
+++ b/companies/underConsideration/Big-Sky-Enterprises.json
@@ -1,0 +1,11 @@
+{
+  "company": "Big Sky Enterprises",
+  "url": "http://bigskyllc.com/employment/",
+  "webSiteUrl": "http://www.bigskyllc.com/",
+  "address": "2 Eastwick Dr., Suite 101, Gibbsboro, NJ 08026",
+  "geo": {
+    "latitude": 39.830696,
+    "longitude": -74.955558
+  },
+  "positions": []
+}

--- a/companies/underConsideration/CRM-Science-Inc.json
+++ b/companies/underConsideration/CRM-Science-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "CRM Science, Inc.",
+  "url": "http://www.crmscience.com/#!careers-crm-science/c1qg9",
+  "webSiteUrl": "http://www.crmscience.com/",
+  "address": "Philadelphia, PA",
+  "geo": {
+    "latitude": 39.952584,
+    "longitude": -75.165222
+  },
+  "positions": []
+}

--- a/companies/underConsideration/CertaPro-Painters-of-the-Main-Line.json
+++ b/companies/underConsideration/CertaPro-Painters-of-the-Main-Line.json
@@ -1,0 +1,11 @@
+{
+  "company": "CertaPro Painters of the Main Line",
+  "url": "http://bryn-mawr.certapro.com/employment-information.aspx",
+  "webSiteUrl": "http://www.certapro.com/mainline/",
+  "address": "24 N. Bryn Mawr Ave. #208, Bryn Mawr, PA 19010",
+  "geo": {
+    "latitude": 40.022097,
+    "longitude": -75.317438
+  },
+  "positions": []
+}

--- a/companies/underConsideration/CorpU.json
+++ b/companies/underConsideration/CorpU.json
@@ -1,0 +1,11 @@
+{
+  "company": "CorpU",
+  "url": "http://www.corpu.com/corpu/about/careers/",
+  "webSiteUrl": "http://www.corpu.com/",
+  "address": "2401 Walnut Street, 7th Floor, Suite 700, Philadelphia, PA 19103",
+  "geo": {
+    "latitude": 39.951521,
+    "longitude": -75.179873
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Digitas-Health.json
+++ b/companies/underConsideration/Digitas-Health.json
@@ -1,0 +1,11 @@
+{
+  "company": "Digitas Health",
+  "url": "http://www.digitashealth.com",
+  "webSiteUrl": "http://www.digitashealth.com/",
+  "address": "100 E Penn Square # 1290, Philadelphia, PA 19107",
+  "geo": {
+    "latitude": 39.94506,
+    "longitude": -75.159786
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Expo-Logic.json
+++ b/companies/underConsideration/Expo-Logic.json
@@ -1,0 +1,11 @@
+{
+  "company": "Expo Logic",
+  "url": "http://ww2.expologic.com/about-us/careers",
+  "webSiteUrl": "http://www.expologic.com/",
+  "address": "553 Foundry Road, East Norriton, PA 19403",
+  "geo": {
+    "latitude": 40.155823,
+    "longitude": -75.370767
+  },
+  "positions": []
+}

--- a/companies/underConsideration/FluidEdge-Consulting-Inc.json
+++ b/companies/underConsideration/FluidEdge-Consulting-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "FluidEdge Consulting, Inc.",
+  "url": "http://www.fluidedgeconsulting.com/careers/",
+  "webSiteUrl": "http://www.fluidedgeconsulting.com/",
+  "address": "10 Mystic Lane, Malvern, PA 19355",
+  "geo": {
+    "latitude": 40.033397,
+    "longitude": -75.578067
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Green-Lawn-Fertilizing.json
+++ b/companies/underConsideration/Green-Lawn-Fertilizing.json
@@ -1,0 +1,11 @@
+{
+  "company": "Green Lawn Fertilizing",
+  "url": "http://www.greenlawnfertilizing.com/careers/",
+  "webSiteUrl": "http://www.greenlawnfertilizing.com/",
+  "address": "1004 Saunders Ln, West Chester, PA 19380",
+  "geo": {
+    "latitude": 39.982973,
+    "longitude": -75.593607
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Grimley-Financial-Corporation.json
+++ b/companies/underConsideration/Grimley-Financial-Corporation.json
@@ -1,0 +1,11 @@
+{
+  "company": "Grimley Financial Corporation",
+  "url": "http://www.grimleyfc.com/employment/",
+  "webSiteUrl": "http://www.grimleyfc.com/",
+  "address": "30 Washington Avenue, Suite C-6, Haddonfield, NJ 08033",
+  "geo": {
+    "latitude": 39.894919,
+    "longitude": -75.035832
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Invision-Security-Group.json
+++ b/companies/underConsideration/Invision-Security-Group.json
@@ -1,0 +1,11 @@
+{
+  "company": "Invision Security Group",
+  "url": "http://www.invisionsecuritygroup.com/about_us/career.html",
+  "webSiteUrl": "http://www.invisionsecuritygroup.com/",
+  "address": "660 W Germantown Pike, Suite 120, Plymouth Meeting, PA 19462",
+  "geo": {
+    "latitude": 40.123597,
+    "longitude": -75.284351
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Jidan-Cleaning.json
+++ b/companies/underConsideration/Jidan-Cleaning.json
@@ -1,0 +1,11 @@
+{
+  "company": "Jidan Cleaning",
+  "url": "http://jidancleaning.com/employment/",
+  "webSiteUrl": "http://www.jidancleaning.com/",
+  "address": "Medford, NJ",
+  "geo": {
+    "latitude": 39.866183,
+    "longitude": -74.839016
+  },
+  "positions": []
+}

--- a/companies/underConsideration/John-Pomp-Studios.json
+++ b/companies/underConsideration/John-Pomp-Studios.json
@@ -1,0 +1,11 @@
+{
+  "company": "John Pomp Studios",
+  "url": "http://www.johnpomp.com/home/careers",
+  "webSiteUrl": "http://www.johnpomp.com/",
+  "address": "1630 N. MASCHER ST., PHILADELPHIA, PA 19122",
+  "geo": {
+    "latitude": 39.975515,
+    "longitude": -75.136618
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Kinetix.json
+++ b/companies/underConsideration/Kinetix.json
@@ -1,0 +1,11 @@
+{
+  "company": "Kinetix",
+  "url": "http://kinetixfire.com/employment/",
+  "webSiteUrl": "http://kinetixfire.com/",
+  "address": "12 Creek Parkway, Boothwyn, PA 19061",
+  "geo": {
+    "latitude": 39.857944,
+    "longitude": -75.464075
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Ladderback-Design.json
+++ b/companies/underConsideration/Ladderback-Design.json
@@ -1,0 +1,11 @@
+{
+  "company": "Ladderback Design",
+  "url": "http://ladderbackdesign.com/opportunities/",
+  "webSiteUrl": "http://ladderbackdesign.com/",
+  "address": "1315 Walnut St., Suite 320, Philadelphia, PA 19107",
+  "geo": {
+    "latitude": 39.9493152971,
+    "longitude": -75.1626386191
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Liberty-Personnel-Services-Inc.json
+++ b/companies/underConsideration/Liberty-Personnel-Services-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Liberty Personnel Services, Inc.",
+  "url": "http://www.libertyjobs.com/jobs.php",
+  "webSiteUrl": "http://www.libertyjobs.com/",
+  "address": "410 Feheley Drive, King of Prussia, PA 19406",
+  "geo": {
+    "latitude": 40.091433,
+    "longitude": -75.338213
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Magic-Hat-Consulting-Inc.json
+++ b/companies/underConsideration/Magic-Hat-Consulting-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Magic Hat Consulting, Inc.",
+  "url": "http://www.magichatconsulting.com/#!careers/c1s1e",
+  "webSiteUrl": "http://www.magichatconsulting.com/",
+  "address": "455 Pennsylvania Avenue, Suite 125, Fort Washington, PA 19034",
+  "geo": {
+    "latitude": 40.135976,
+    "longitude": -75.20793
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Main-Line-Energy-Consultants-LLC.json
+++ b/companies/underConsideration/Main-Line-Energy-Consultants-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Main Line Energy Consultants, LLC",
+  "url": "http://www.mainlec.com/#!about-us-2/c13wd",
+  "webSiteUrl": "http://www.mainlec.com/",
+  "address": "1240 South Broad Street, Suite 100, Lansdale, PA 19446",
+  "geo": {
+    "latitude": 40.223076,
+    "longitude": -75.30247
+  },
+  "positions": []
+}

--- a/companies/underConsideration/McDonald-Building-Company.json
+++ b/companies/underConsideration/McDonald-Building-Company.json
@@ -1,0 +1,11 @@
+{
+  "company": "McDonald Building Company",
+  "url": "http://www.mcdonaldbc.com/careers",
+  "webSiteUrl": "http://www.mcdonaldbc.com/",
+  "address": "910 East Main Street, Suite 101, Norristown, PA 19401",
+  "geo": {
+    "latitude": 40.108366,
+    "longitude": -75.32683
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Medical-Guardian-LLC.json
+++ b/companies/underConsideration/Medical-Guardian-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Medical Guardian, LLC",
+  "url": "https://medicalguardian.silkroad.com/",
+  "webSiteUrl": "http://www.medicalguardian.com/",
+  "address": "1818 Market Street, Suite 1200, Philadelphia, PA 19103",
+  "geo": {
+    "latitude": 39.952924,
+    "longitude": -75.171026
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Metropolitan-Acoustics-LLC.json
+++ b/companies/underConsideration/Metropolitan-Acoustics-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Metropolitan Acoustics, LLC",
+  "url": "http://metro-acoustics.com/careers",
+  "webSiteUrl": "http://www.metro-acoustics.com/",
+  "address": "40 West Evergreen Avenue, Suite 108, Philadelphia, PA 19118",
+  "geo": {
+    "latitude": 40.075344,
+    "longitude": -75.208319
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Millennium-Administrators-Inc.json
+++ b/companies/underConsideration/Millennium-Administrators-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Millennium Administrators, Inc.",
+  "url": "http://www.millennium-tpa.com/Html/career.html",
+  "webSiteUrl": "http://www.millennium-tpa.com/",
+  "address": "900 Ashbourne Way, Suite B, Schwenksville, PA 19473",
+  "geo": {
+    "latitude": 40.237618,
+    "longitude": -75.397853
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Monument-LLC.json
+++ b/companies/underConsideration/Monument-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Monument, LLC",
+  "url": "http://www.monumentllc.com/why-monument/careers",
+  "webSiteUrl": "http://www.monumentllc.com/",
+  "address": "255 Great Valley Parkway, Suite 200, Malvern, PA 19355",
+  "geo": {
+    "latitude": 40.060337,
+    "longitude": -75.54245
+  },
+  "positions": []
+}

--- a/companies/underConsideration/MoreVent-Heating-Cooling-Plumbing.json
+++ b/companies/underConsideration/MoreVent-Heating-Cooling-Plumbing.json
@@ -1,0 +1,11 @@
+{
+  "company": "MoreVent Heating Cooling Plumbing",
+  "url": "http://moreventservices.com/careers/",
+  "webSiteUrl": "http://www.moreventservices.com/",
+  "address": "1041 Andrew Drive, West Chester, PA 19380",
+  "geo": {
+    "latitude": 39.987211,
+    "longitude": -75.590776
+  },
+  "positions": []
+}

--- a/companies/underConsideration/NEST.json
+++ b/companies/underConsideration/NEST.json
@@ -1,0 +1,11 @@
+{
+  "company": "NEST",
+  "url": "http://www.enternest.com/about-nest/careers/",
+  "webSiteUrl": "http://www.enternest.com/",
+  "address": "822 Klemm Avenue, Gloucester City, NJ 08030",
+  "geo": {
+    "latitude": 39.890234,
+    "longitude": -75.103327
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Nathan-Sports-Inc.json
+++ b/companies/underConsideration/Nathan-Sports-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Nathan Sports, Inc.",
+  "url": "http://www.nathansports.com/careers",
+  "webSiteUrl": "http://www.nathansports.com/",
+  "address": "2009 Elmwood Ave., Suite 101, Sharon Hill, PA 19079",
+  "geo": {
+    "latitude": 39.907337,
+    "longitude": -75.259501
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Navigate.json
+++ b/companies/underConsideration/Navigate.json
@@ -1,0 +1,11 @@
+{
+  "company": "Navigate",
+  "url": "http://www.navigatecorp.com/careers/",
+  "webSiteUrl": "http://navigatecorp.com/",
+  "address": "1200 Liberty Ridge Drive, Suite 125, Wayne, PA 19087",
+  "geo": {
+    "latitude": 40.0684514,
+    "longitude": -75.4655797
+  },
+  "positions": []
+}

--- a/companies/underConsideration/New-Way-Air-Bearings.json
+++ b/companies/underConsideration/New-Way-Air-Bearings.json
@@ -1,0 +1,11 @@
+{
+  "company": "New Way Air Bearings",
+  "url": "http://www.newwayairbearings.com/new-way/careers",
+  "webSiteUrl": "http://www.newwayairbearings.com/",
+  "address": "50 McDonald Blvd., Aston, PA  19014",
+  "geo": {
+    "latitude": 39.850729,
+    "longitude": -75.406896
+  },
+  "positions": []
+}

--- a/companies/underConsideration/OneTwoSee.json
+++ b/companies/underConsideration/OneTwoSee.json
@@ -1,0 +1,11 @@
+{
+  "company": "OneTwoSee",
+  "url": "https://www.linkedin.com/company/onetwosee",
+  "webSiteUrl": "http://onetwosee.com/",
+  "address": "1650 Arch Street Philadelphia, PA 19103, Suite 1810",
+  "geo": {
+    "latitude": 39.95466,
+    "longitude": -75.167697
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Partners-Consulting-Inc.json
+++ b/companies/underConsideration/Partners-Consulting-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Partner's Consulting Inc.",
+  "url": "http://partners-consulting.com/opportunities",
+  "webSiteUrl": "http://www.partners-consulting.com/",
+  "address": "2004 Sproul Road, Suite 206, Broomall, PA 19008",
+  "geo": {
+    "latitude": 39.963969,
+    "longitude": -75.357873
+  },
+  "positions": []
+}

--- a/companies/underConsideration/PennFleet-Corp.json
+++ b/companies/underConsideration/PennFleet-Corp.json
@@ -1,0 +1,11 @@
+{
+  "company": "PennFleet Corp.",
+  "url": "http://pennfleet.com/category/employment/",
+  "webSiteUrl": "http://pennfleet.com/",
+  "address": "591 Meetinghouse Road, Boothwyn PA 19061",
+  "geo": {
+    "latitude": 39.838764,
+    "longitude": -75.429541
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Pentec-Health-Inc.json
+++ b/companies/underConsideration/Pentec-Health-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Pentec Health Inc",
+  "url": "http://www.pentechealth.com/careers.html",
+  "webSiteUrl": "http://www.pentechealth.com/",
+  "address": "Philadelphia, PA",
+  "geo": {
+    "latitude": 39.952584,
+    "longitude": -75.165222
+  },
+  "positions": []
+}

--- a/companies/underConsideration/PetroMar-Technologies-Inc.json
+++ b/companies/underConsideration/PetroMar-Technologies-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "PetroMar Technologies, Inc.",
+  "url": "http://www.petromartech.com/careers/",
+  "webSiteUrl": "http://www.petromartech.com/",
+  "address": "440 Creamery Way, Suite 100, Exton, PA 19341",
+  "geo": {
+    "latitude": 40.016752,
+    "longitude": -75.653774
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Pine-Hill-Group-LLC.json
+++ b/companies/underConsideration/Pine-Hill-Group-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Pine Hill Group, LLC",
+  "url": "https://careers-thepinehillgroup.icims.com/jobs/intro?hashed=-435707994&mobile=false&width=631&height=500&bga=true&needsRedirect=false&jan1offset=-300&jun1offset=-240",
+  "webSiteUrl": "http://www.thepinehillgroup.com/",
+  "address": "1835 Market Street, Suite 910, Philadelphia, PA 19103",
+  "geo": {
+    "latitude": 39.953688,
+    "longitude": -75.171139
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Prime-Technology-Group-LLC.json
+++ b/companies/underConsideration/Prime-Technology-Group-LLC.json
@@ -1,0 +1,11 @@
+{
+  "company": "Prime Technology Group, LLC.",
+  "url": "http://www.primetgi.com/prime-careers/",
+  "webSiteUrl": "http://www.primetgi.com/",
+  "address": "940 W Valley Rd, Suite 1500, Wayne, PA 19087",
+  "geo": {
+    "latitude": 40.068462,
+    "longitude": -75.427052
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Swain-Techs.json
+++ b/companies/underConsideration/Swain-Techs.json
@@ -1,0 +1,11 @@
+{
+  "company": "Swain Techs",
+  "url": "http://www.swaintechs.com/careers",
+  "webSiteUrl": "http://www.swaintechs.com/",
+  "address": "2 Walnut Grove Drive, Suite 110, Horsham, PA 19044",
+  "geo": {
+    "latitude": 40.167971,
+    "longitude": -75.144413
+  },
+  "positions": []
+}

--- a/companies/underConsideration/TekSolv.json
+++ b/companies/underConsideration/TekSolv.json
@@ -1,0 +1,11 @@
+{
+  "company": "TekSolv",
+  "url": "http://www.indeed.com/cmp/Teksolv",
+  "webSiteUrl": "http://www.teksolv.com/",
+  "address": "130 Executive Dr., Suite 5, Newark, DE 19702",
+  "geo": {
+    "latitude": 39.618606,
+    "longitude": -75.749808
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Tembo-Inc.json
+++ b/companies/underConsideration/Tembo-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Tembo, Inc.",
+  "url": "http://temboinc.com/careers/",
+  "webSiteUrl": "http://temboinc.com/",
+  "address": "1639 North Hancock Street, Suite 203, Philadelphia, PA 19122",
+  "geo": {
+    "latitude": 39.975553,
+    "longitude": -75.136921
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Therapy-Source-Inc.json
+++ b/companies/underConsideration/Therapy-Source-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "Therapy Source, Inc.",
+  "url": "http://txsource.com/about-us/join-our-team/",
+  "webSiteUrl": "http://www.txsource.net/",
+  "address": "5215 Militia Hill Road, Suite A, Plymouth Meeting, PA 19462",
+  "geo": {
+    "latitude": 40.118134,
+    "longitude": -75.255581
+  },
+  "positions": []
+}

--- a/companies/underConsideration/ThreatQuotient-Inc.json
+++ b/companies/underConsideration/ThreatQuotient-Inc.json
@@ -1,0 +1,11 @@
+{
+  "company": "ThreatQuotient, Inc.",
+  "url": "https://www.threatq.com/careers/",
+  "webSiteUrl": "https://www.threatq.com/",
+  "address": "",
+  "geo": {
+    "latitude": null,
+    "longitude": null
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Tierney.json
+++ b/companies/underConsideration/Tierney.json
@@ -1,0 +1,11 @@
+{
+  "company": "Tierney",
+  "url": "https://tierneyagency-openhire.silkroad.com/epostings/index.cfm?company_id=16934",
+  "webSiteUrl": "http://www.hellotierney.com/",
+  "address": "200 S. Broad St., 10th Fl, Philadelphia, PA 19102",
+  "geo": {
+    "latitude": 39.949195,
+    "longitude": -75.164338
+  },
+  "positions": []
+}

--- a/companies/underConsideration/Unilife-Corporation.json
+++ b/companies/underConsideration/Unilife-Corporation.json
@@ -1,0 +1,11 @@
+{
+  "company": "Unilife Corporation",
+  "url": "http://www.unilife.com/careers",
+  "webSiteUrl": "http://www.unilife.com/",
+  "address": "150 South Warner Road, King of Prussia, PA 19406",
+  "geo": {
+    "latitude": 40.080512,
+    "longitude": -75.400511
+  },
+  "positions": []
+}

--- a/companies/underConsideration/eMaint-Enterprises.json
+++ b/companies/underConsideration/eMaint-Enterprises.json
@@ -1,0 +1,11 @@
+{
+  "company": "eMaint Enterprises",
+  "url": "http://www.emaint.com/careers/",
+  "webSiteUrl": "http://www.emaint.com/",
+  "address": "438 N. Elmwood Road, Marlton, NJ 08053",
+  "geo": {
+    "latitude": 39.9015,
+    "longitude": -74.8815
+  },
+  "positions": []
+}


### PR DESCRIPTION
These are most of the companies that I pulled from a some sources.
PhlDesign, Philadelphia Top 100 companies to work for, and NET/WORK job
fair. Companies that had job positions have already been put in. These
are most of the remaining companies. The “underConsideration” companies
have a career url, but not open positions listed. The “needCareerUrl”
companies don’t meet the job page requirement. In any case, it is
possible that some of the companies may never have tech positions and
should be deleted.